### PR TITLE
chore: v1.0.3 release — layout fix, extreme-script baselines, playgro…

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -47,10 +47,12 @@ src/
 └── worker/       # Web Worker dispatch + self-contained worker entry
 fonts/            # Pre-built font data modules (.js/.d.ts) — 16 scripts + TTF source files
 tools/            # CLI tool (build-font-data.cjs) for converting TTF → importable data modules
-scripts/          # Modular sample PDF generation (23 generators, 140+ PDFs)
-tests/            # 1588+ tests (40 files: unit/integration/fuzz/parser) mirroring src/ structure
+scripts/          # Modular sample PDF generation (24 generators, 140+ PDFs; extreme-shaping.ts added in v1.0.3)
+test-output/extreme/  # Visual regression baselines for extreme scripts (extreme-bidi.pdf, extreme-tamil.pdf, extreme-bengali-devanagari.pdf, extreme-arabic-harakat.pdf)
+tests/            # 1606+ tests (41 files: unit/integration/fuzz/parser) mirroring src/ structure
 bench/            # Performance benchmarks (vitest bench)
 docs/             # GitHub Pages landing site (pdfnative.dev) — pure HTML/CSS/JS, zero build deps
+  └── playgrounds/  # Interactive browser playgrounds (extreme-scripts.html, medical-800.html)
 ```
 
 - **Single entry point**: `src/index.ts` re-exports everything. All public API surfaces live there.
@@ -76,7 +78,7 @@ npm run build           # tsup → dist/ (ESM + CJS + .d.ts)
 npm run test            # vitest run (1588+ tests, 40 files)
 npm run test:watch      # vitest (watch mode)
 npm run test:coverage   # vitest with v8 coverage (thresholds: 90/80/85/90)
-npm run test:generate   # Generate 140+ sample PDFs → test-output/
+npm run test:generate   # Generate 140+ sample PDFs → test-output/ (incl. extreme/ baselines)
 npm run typecheck       # tsc --noEmit
 npm run typecheck:tests # tsc --project tsconfig.test.json --noEmit
 npm run typecheck:scripts # tsc --project tsconfig.scripts.json --noEmit
@@ -225,7 +227,7 @@ npm run lint            # eslint src/ (ESLint 9 + typescript-eslint strict)
 - **PDF /Info metadata** — Title, Producer (pdfnative), CreationDate in D:YYYYMMDDHHmmss format
 - **Input validation** — at `buildPDF()` boundary: null/undefined/type checks, 100K row limit
 - **URL validation** — at `validateURL()`: blocks javascript:, file:, data: schemes
-- **95%+ test coverage** — 1588+ tests (40 files), 48 fuzz edge-cases (including recursion/zip-bomb/xref-chain hardening), performance benchmarks
+- **95%+ test coverage** — 1606+ tests (41 files), 48 fuzz edge-cases (including recursion/zip-bomb/xref-chain hardening), performance benchmarks
 - **NPM provenance** — signed builds via GitHub Actions OIDC
 - Security: no `eval()`, no `Function()`, no dynamic code execution
 - No `console.log` in library code (only in tools/ and scripts/)

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ fonts/ttf/
 
 # Generated sample PDFs for visual inspection
 test-output/
+
+# Draft GitHub issues (copy-paste helpers, never committed)
+release-notes/draft-*.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,26 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+## [1.0.3] – 2026-04-25
 
-- **docs(landing):** added a row of project-status badges to the
-  `pdfnative.dev` hero (CI, CodeQL, OpenSSF Scorecard, npm version, monthly
-  downloads, bundle size, zero deps, TypeScript strict, npm provenance, MIT)
-  to mirror the `README.md` and surface supply-chain signals upfront.
-- **docs(landing):** rebuilt the "Try It Live" panel as a curated
-  10-example gallery (Quick Start, Financial, TOC, Barcode, SVG, Watermark,
-  Forms, PDF/A, Multi-language with lazy fonts, Streaming) with a picker,
-  reset button, and a "View source" link to the matching generator under
-  `scripts/generators/`. The runtime now supports top-level `await`,
-  dynamic `import(…)`, and exposes `streamDocumentPdf`, `registerFonts`,
-  `loadFontData`, and `signPdfBytes`.
-- **docs(landing):** synced the test counter to 1 588+ tests (matches
-  `tests/` and `package.json`).
-- **docs(landing):** added a "Guides" entry in the navbar and refreshed the
-  footer with direct links to every guide.
+### Fixed
+
+- **core(layout):** `wrapText()` now hard-breaks single overlong tokens at
+  character boundaries when no whitespace breakpoint exists. Long
+  headings and titles such as
+  `"Test Bengali + Devanagari ULTRA EXTREME — Shaping & Positioning — pdfnative"`
+  previously could overflow the right margin when no segment fit. Code
+  points are honored so surrogate pairs and combining sequences remain
+  intact at slice boundaries. ([src/core/pdf-renderers.ts](src/core/pdf-renderers.ts))
+- **docs(landing):** footer links to `guides/architecture.html` and
+  `guides/faq.html` previously 404'd because only `.md` files existed
+  under `docs/guides/` and `.nojekyll` disables auto-rendering. Each
+  guide now ships as a real HTML page with a clean URL.
 
 ### Added
 
+- **scripts(generators):** new `extreme-shaping.ts` generator producing
+  four visual-regression baselines under `test-output/extreme/`:
+  `extreme-bidi.pdf` (Arabic + Hebrew + Thai + Latin + digits),
+  `extreme-tamil.pdf` (deep conjuncts, split vowels, BiDi mix),
+  `extreme-bengali-devanagari.pdf` (reph + multi-halant chains),
+  `extreme-arabic-harakat.pdf` (isolated tashkeel anchoring).
+- **tests(integration):** `tests/integration/extreme-shaping.test.ts` —
+  five end-to-end builds covering the same extreme inputs to guard
+  against pipeline regressions.
+- **tests(core):** new regression tests for `wrapText` confirming
+  character-level hard-break of overlong tokens and multi-line wrapping
+  of long em-dash titles.
+- **docs(playgrounds):** new interactive playground
+  `docs/playgrounds/extreme-scripts.html` for stress-testing BiDi, Tamil
+  conjuncts, Bengali + Devanagari ligatures, and Arabic harakat directly
+  in the browser, with editable presets and a code preview.
+- **docs(playgrounds):** new
+  `docs/playgrounds/medical-800.html` — Web Worker showcase generating
+  an 800-page synthetic clinical report using `buildDocumentPDFStream`,
+  with live progress, byte/chunk counters, optional Tagged PDF (PDF/A-2b),
+  and a main-thread comparison toggle. All patient data is generated
+  client-side from a seeded RNG — no real PHI.
 - **docs(guides):** static HTML guide pages (`quickstart.html`,
   `architecture.html`, `faq.html`, `troubleshooting.html`,
   `accessibility.html`) plus a guides index at `/guides/`. Each page
@@ -48,12 +68,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   table was not updated. Added a "Citing pdfnative" section with BibTeX
   pointing to `CITATION.cff`.
 
-### Fixed
+### Changed
 
-- **docs(landing):** footer links to `guides/architecture.html` and
-  `guides/faq.html` previously 404'd because only `.md` files existed
-  under `docs/guides/` and `.nojekyll` disables auto-rendering. Each
-  guide now ships as a real HTML page with a clean URL.
+- **docs(landing):** added a row of project-status badges to the
+  `pdfnative.dev` hero (CI, CodeQL, OpenSSF Scorecard, npm version, monthly
+  downloads, bundle size, zero deps, TypeScript strict, npm provenance, MIT)
+  to mirror the `README.md` and surface supply-chain signals upfront.
+- **docs(landing):** rebuilt the "Try It Live" panel as a curated
+  10-example gallery (Quick Start, Financial, TOC, Barcode, SVG, Watermark,
+  Forms, PDF/A, Multi-language with lazy fonts, Streaming) with a picker,
+  reset button, and a "View source" link to the matching generator under
+  `scripts/generators/`. The runtime now supports top-level `await`,
+  dynamic `import(…)`, and exposes `streamDocumentPdf`, `registerFonts`,
+  `loadFontData`, and `signPdfBytes`.
+- **docs(landing):** synced the test counter to 1 588+ tests (matches
+  `tests/` and `package.json`).
+- **docs(landing):** added "Guides" and "Playgrounds" entries in the
+  navbar and refreshed the footer with direct links to every guide and
+  both new playgrounds.
+
+### Known limitations (tracked for v1.1.0)
+
+The following deeper shaping issues are surfaced by the new extreme
+samples and are tracked for the next minor release. They require
+either GPOS table re-extraction in the pre-built font data modules or
+new OpenType lookups in the shaping pipeline, which exceed the scope of
+a SemVer-patch:
+
+- Arabic isolated harakat (تشكيل) without a base consonant fall back to
+  default mark positioning rather than precise font-anchored placement.
+- Thai mark stacking on tall consonants (ป ฝ ฟ ฬ) with three or more
+  combining marks may overlap with the current font anchor data.
+- Multi-stage Indic ligatures (ক্ষ্ম, क्ष्म, ஸ்ரீ) are matched greedily;
+  some deeply-nested sequences fall back to non-ligated forms.
+- BiDi paragraphs mixing 3+ RTL-capable scripts (Arabic + Hebrew + Thai
+  + Latin + digits) may exhibit non-canonical run ordering at boundaries
+  with neutrals.
+
+See [release-notes/draft-issue-v1.1.0-shaping-epic.md](release-notes/draft-issue-v1.1.0-shaping-epic.md)
+for the full follow-up tracking issue.
+
+[#24]: https://github.com/Nizoka/pdfnative/issues/24
+[1.0.3]: https://github.com/Nizoka/pdfnative/compare/v1.0.2...v1.0.3
 
 ## [1.0.2] – 2026-04-24
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,10 +23,38 @@ npm run build          # tsup → dist/ (ESM + CJS + .d.ts)
 npm run dev            # tsup --watch
 ```
 
+## Docs local preview
+
+The documentation site (`docs/`) is a static HTML/CSS/JS site with no build step.
+Openin `docs/index.html` directly as a `file://` URL works for most pages, but
+the **interactive playgrounds** require an HTTP origin because they load pdfnative
+from a CDN inside a Web Worker and `file:` origins block cross-origin Worker imports.
+
+Serve the site locally with the included npm script:
+
+```bash
+npm run docs:serve
+# → http://localhost:5000
+```
+
+Or use any static file server:
+
+```bash
+npx serve docs/ --listen 5000      # same as npm run docs:serve
+npx http-server docs/ -p 5000      # alternative
+python -m http.server 5000 --directory docs/   # Python stdlib, no install
+```
+
+Then open:
+- `http://localhost:5000/` — landing page
+- `http://localhost:5000/playgrounds/extreme-scripts.html` — extreme-scripts playground
+- `http://localhost:5000/playgrounds/medical-800.html` — medical 800-page playground
+- `http://localhost:5000/guides/` — guides index
+
 ## Test
 
 ```bash
-npm run test           # vitest run (1588+ tests)
+npm run test           # vitest run (1606+ tests)
 npm run test:watch     # vitest (watch mode)
 npm run test:coverage  # vitest with v8 coverage (95%+ stmts)
 npm run test:generate  # Generate 140+ sample PDFs → test-output/
@@ -71,8 +99,8 @@ src/
 └── worker/       # Web Worker dispatch + self-contained worker entry
 fonts/            # Pre-built font data modules (16 scripts)
 tools/            # CLI tool for converting TTF → importable data modules
-scripts/          # Modular sample PDF generation (23 generators, 140+ PDFs)
-tests/            # 1588+ tests (40 files: unit + integration + fuzz + parser), mirrors src/ structure
+scripts/          # Modular sample PDF generation (24 generators, 140+ PDFs)
+tests/            # 1606+ tests (41 files: unit + integration + fuzz + parser), mirrors src/ structure
 bench/            # Performance benchmarks (vitest bench)
 ```
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ npm install pdfnative
 - ♿ **Accessibility:** [docs/guides/accessibility.md](docs/guides/accessibility.md) — tagged PDF, PDF/UA, PDF/A.
 - ❓ **FAQ:** [docs/guides/faq.md](docs/guides/faq.md) — fonts, encryption, signatures, comparisons.
 - 🛠️ **Troubleshooting:** [docs/guides/troubleshooting.md](docs/guides/troubleshooting.md) — common pitfalls.
+- 🎮 **Playgrounds:** [docs/playgrounds/extreme-scripts.html](docs/playgrounds/extreme-scripts.html) (live BiDi/Indic stress tests) and [docs/playgrounds/medical-800.html](docs/playgrounds/medical-800.html) (800-page Web Worker showcase).
 - 🧪 **Sample PDFs:** [scripts/generators/](scripts/generators/) — ~140 sample PDFs across 23 categories (see [Sample PDFs](#sample-pdfs) below).
 
 ## Why pdfnative?

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,7 +39,22 @@ This document outlines the planned development direction for pdfnative. Prioriti
 
 ## In Progress
 
-_No items currently in progress._
+### v1.1.0 — Deep OpenType shaping & BiDi (tracked from v1.0.3 baselines)
+
+The v1.0.3 release shipped four extreme-script visual baselines under
+`test-output/extreme/` that surface deeper shaping defects requiring
+GPOS table re-extraction or new OpenType lookup implementations. These
+exceed the scope of a SemVer-patch and are tracked here for v1.1.0.
+See [release-notes/draft-issue-v1.1.0-shaping-epic.md](release-notes/draft-issue-v1.1.0-shaping-epic.md)
+for the full root-cause analysis.
+
+- [ ] **shaping(bidi):** full UAX #9 W1–W7 + N1/N2 + isolates (3+ script paragraphs)
+- [ ] **shaping(common):** multi-pass GSUB driver for nested LookupType 4 ligatures
+- [ ] **shaping(devanagari/bengali):** Universal Shaping Engine (USE)-lite cluster classification
+- [ ] **shaping(arabic):** GPOS MarkBasePos for isolated harakat anchoring
+- [ ] **fonts(thai):** re-extract GPOS anchors covering 3+ mark stacks on tall consonants
+- [ ] **fonts(indic):** verify pre-built `ligatures` tables include deeply-nested chains
+- [ ] **tests(visual):** pixel-diff regression on the four `extreme-*` baselines
 
 ## Planned
 

--- a/docs/guides/index.html
+++ b/docs/guides/index.html
@@ -69,6 +69,18 @@
     <h2>Looking for samples?</h2>
     <p>The repository ships with <a href="https://github.com/Nizoka/pdfnative/tree/main/scripts/generators" target="_blank" rel="noopener">23 generator categories producing ~140 sample PDFs</a> covering every feature: financial statements, multi-language documents, barcodes, SVG, watermarks, forms, encryption, signatures, streaming, parser, and stress tests.</p>
 
+    <h2>Interactive playgrounds</h2>
+    <ul class="guide-toc-list">
+      <li>
+        <a href="../playgrounds/extreme-scripts.html">Extreme scripts playground →</a>
+        <span class="guide-toc-desc">Stress-test BiDi (Arabic + Hebrew + Thai), Tamil deep conjuncts, Bengali &amp; Devanagari reph + ligature chains, and isolated Arabic harakat directly in the browser.</span>
+      </li>
+      <li>
+        <a href="../playgrounds/medical-800.html">Medical 800-page Web Worker playground →</a>
+        <span class="guide-toc-desc">Generate a synthetic 800-page clinical report off the main thread using a Web Worker. Live progress, streaming output, optional Tagged PDF.</span>
+      </li>
+    </ul>
+
     <h2>Contributing</h2>
     <p>Found a typo, an unclear paragraph, or a missing topic? Edit the underlying <code>.md</code> file directly on <a href="https://github.com/Nizoka/pdfnative/tree/main/docs/guides" target="_blank" rel="noopener">GitHub</a> and open a pull request. See <a href="https://github.com/Nizoka/pdfnative/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener">CONTRIBUTING.md</a> for branch naming conventions (<code>docs/*</code>).</p>
   </article>

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -167,6 +167,20 @@ const pdf = concatChunks(chunks);
 
 The async iterable yields `Uint8Array` chunks as the PDF is produced — no full-document buffering. The three-argument API (`params`, `layoutOptions`, `streamOptions`) keeps layout concerns (tagged, compress, watermark) and streaming concerns (chunk size) separate.
 
+## Playgrounds
+
+Both interactive playgrounds on [pdfnative.dev](https://pdfnative.dev) run entirely in the browser:
+
+- [Extreme scripts](../playgrounds/extreme-scripts.html) — live BiDi, Tamil, Bengali + Devanagari, Arabic harakat
+- [Medical 800-page](../playgrounds/medical-800.html) — Web Worker + streaming showcase
+
+> **Local testing:** opening the playgrounds as `file://` disables the Web Worker
+> (browsers block cross-origin Worker imports from `file:` origins).
+> Serve the docs directory instead:
+> ```bash
+> npm run docs:serve   # → http://localhost:5000
+> ```
+
 ## Next steps
 
 - [Architecture](architecture.html) — modules, builders, generation pipeline.

--- a/docs/index.html
+++ b/docs/index.html
@@ -64,6 +64,7 @@
       <li><a href="#benchmarks">Benchmarks</a></li>
       <li><a href="#architecture">Architecture</a></li>
       <li><a href="guides/">Guides</a></li>
+      <li><a href="playgrounds/extreme-scripts.html">Playgrounds</a></li>
       <li><a href="https://github.com/Nizoka/pdfnative" target="_blank" rel="noopener">GitHub</a></li>
       <li><button class="theme-toggle" aria-label="Toggle dark mode">🌙</button></li>
     </ul>
@@ -534,6 +535,8 @@ const pdf = buildDocumentPDFBytes({
       <li><a href="guides/faq.html">FAQ</a></li>
       <li><a href="guides/troubleshooting.html">Troubleshooting</a></li>
       <li><a href="guides/accessibility.html">Accessibility</a></li>
+      <li><a href="playgrounds/extreme-scripts.html">Extreme scripts playground</a></li>
+      <li><a href="playgrounds/medical-800.html">Medical 800-page playground</a></li>
       <li><a href="https://plika.app" target="_blank" rel="noopener">Originally from Plika.app</a></li>
     </ul>
   </div>

--- a/docs/playgrounds/extreme-scripts.html
+++ b/docs/playgrounds/extreme-scripts.html
@@ -1,0 +1,275 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Extreme Scripts Playground — pdfnative</title>
+  <meta name="description" content="Interactive playground for extreme-script shaping: Arabic + Hebrew + Thai BiDi, Tamil deep conjuncts, Bengali + Devanagari reph and ligatures, Arabic isolated harakat. Edit the inputs and generate a PDF in your browser.">
+  <link rel="canonical" href="https://pdfnative.dev/playgrounds/extreme-scripts.html">
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+  <link rel="stylesheet" href="../style.css">
+  <link rel="stylesheet" href="../guides/guide.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-tomorrow.min.css">
+</head>
+<body>
+
+<nav class="nav" role="navigation" aria-label="Main navigation">
+  <div class="nav-inner">
+    <a class="nav-brand" href="../">
+      <img src="../assets/logo.svg" alt="" width="28" height="28">
+      pdfnative
+    </a>
+    <button class="nav-hamburger" aria-label="Toggle menu" aria-expanded="false">☰</button>
+    <ul class="nav-links" role="list">
+      <li><a href="../#features">Features</a></li>
+      <li><a href="../#examples">Examples</a></li>
+      <li><a href="../#demo">Demo</a></li>
+      <li><a href="./extreme-scripts.html" aria-current="page">Extreme</a></li>
+      <li><a href="./medical-800.html">Medical 800p</a></li>
+      <li><a href="../guides/">Guides</a></li>
+      <li><a href="https://github.com/Nizoka/pdfnative" target="_blank" rel="noopener">GitHub</a></li>
+      <li><button class="theme-toggle" aria-label="Toggle dark mode">🌙</button></li>
+    </ul>
+  </div>
+</nav>
+
+<main class="guide-shell">
+  <p class="guide-breadcrumb"><a href="../">Home</a> &nbsp;›&nbsp; Playgrounds &nbsp;›&nbsp; Extreme scripts</p>
+  <article class="guide-content">
+    <h1>Extreme Scripts Playground</h1>
+    <p>Stress-test the pdfnative shaping pipeline against the most demanding inputs: deep BiDi mixing across 3+ scripts, Tamil ultra-conjuncts, Bengali &amp; Devanagari with reph + multi-halant ligature chains, and isolated Arabic harakat. Pick a preset, edit the text, and click <strong>Generate PDF</strong>.</p>
+
+    <div id="status" style="display:none;padding:10px 14px;border-radius:6px;margin:16px 0;font-size:14px;"></div>
+
+    <div style="display:flex;gap:12px;flex-wrap:wrap;align-items:center;margin-top:24px;">
+      <label for="preset"><strong>Preset:</strong></label>
+      <select id="preset" style="padding:6px 10px;border-radius:6px;border:1px solid #cbd5e1;font-size:14px;">
+        <option value="bidi">Extreme BiDi — Arabic + Hebrew + Thai + Latin + digits</option>
+        <option value="tamil">Tamil ultra-extreme — conjuncts &amp; split vowels</option>
+        <option value="bengali">Bengali + Devanagari — reph &amp; ligature chains</option>
+        <option value="harakat">Arabic harakat — isolated diacritics</option>
+      </select>
+      <button id="generate" class="btn btn-primary" style="padding:8px 18px;">Generate PDF</button>
+      <span id="timer" style="font-size:13px;color:#64748b;"></span>
+    </div>
+
+    <h2 style="margin-top:32px;">Document title</h2>
+    <input id="title" type="text" style="width:100%;padding:10px;border-radius:6px;border:1px solid #cbd5e1;font-size:14px;font-family:monospace;">
+
+    <h2 style="margin-top:24px;">Heading (H1)</h2>
+    <input id="heading" type="text" style="width:100%;padding:10px;border-radius:6px;border:1px solid #cbd5e1;font-size:14px;font-family:monospace;">
+
+    <h2 style="margin-top:24px;">Body paragraphs <span style="font-weight:400;color:#64748b;font-size:14px;">(one per line; blank line for a new paragraph)</span></h2>
+    <textarea id="body" rows="14" style="width:100%;padding:10px;border-radius:6px;border:1px solid #cbd5e1;font-size:14px;font-family:monospace;line-height:1.5;"></textarea>
+
+    <details style="margin-top:24px;">
+      <summary style="cursor:pointer;font-weight:600;">View underlying code</summary>
+      <pre style="margin-top:12px;"><code id="code-view" class="language-typescript"></code></pre>
+    </details>
+
+    <div style="margin-top:32px;padding:16px;background:#fffbeb;border:1px solid #fde68a;border-radius:8px;">
+      <strong style="color:#78350f;">Known shaping limitations (v1.0.3):</strong>
+      <ul style="margin-top:8px;color:#78350f;">
+        <li>Arabic isolated harakat (تشكيل) without a base consonant may render with default GPOS positioning rather than precise font anchors. <a href="https://github.com/Nizoka/pdfnative/issues" target="_blank" rel="noopener">Tracked issue →</a></li>
+        <li>Thai mark stacking on tall consonants (ป ฝ ฟ ฬ) relies on font anchor data; some 3+ mark combinations may overlap with v1.0.3 fonts.</li>
+        <li>Multi-stage Indic ligatures (ক্ষ্ম, क्ष्म) are matched greedily; some sequences with deep nesting may fall back to non-ligated forms.</li>
+      </ul>
+      <p style="color:#78350f;margin-top:8px;font-size:14px;">These limitations are tracked for the v1.1 minor release. The visual baseline is preserved in <code>test-output/extreme/</code>.</p>
+    </div>
+  </article>
+</main>
+
+<footer class="footer">
+  <div class="footer-inner">
+    <span>MIT License · © 2026 Nizoka</span>
+    <ul class="footer-links" role="list">
+      <li><a href="https://github.com/Nizoka/pdfnative" target="_blank" rel="noopener">GitHub</a></li>
+      <li><a href="../guides/">All guides</a></li>
+      <li><a href="./medical-800.html">Medical 800-page playground →</a></li>
+    </ul>
+  </div>
+</footer>
+
+<script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/prism.min.js" defer></script>
+<script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-typescript.min.js" defer></script>
+<script type="module">
+const PRESETS = {
+  bidi: {
+    title: 'Extreme BiDi',
+    heading: 'Extreme BiDi — Arabic + Hebrew + Thai + Latin + Numerals',
+    langs: ['ar', 'he', 'th'],
+    body: [
+      'مثال BiDi قوي: السلام عليكم 654321 — שלום עולם — สวัสดี + Hello from Thailand 789.',
+      '',
+      'هذا اختبار للـ shaping المتقدم في اللغة العربية: السلام عليكم ورحمة الله وبركاته.',
+      '',
+      'בדיקה של טקסט עברי מורכב עם ניקוד: שָׁלוֹם עֲלֵיכֶם.',
+      '',
+      'การทดสอบภาษาไทย: สวัสดีครับ ขอบคุณมากครับ ภาษาไทยมีพยัญชนะและสระและวรรณยุกต์.'
+    ].join('\n')
+  },
+  tamil: {
+    title: 'Extreme Tamil',
+    heading: 'Tamil ultra-extreme — shaping & positioning',
+    langs: ['ta', 'ar'],
+    body: [
+      'எழுத்துக்களின் stacking: க கா கி கீ கு கூ கெ கே கை கொ கோ கௌ க்ஷ க்ஷி க்ஷீ க்ஷு க்ஷூ.',
+      '',
+      'BiDi extreme mix: வணக்கம் ௧௨௩௪௫ — 123456 — السلام عليكم — Hello from தமிழ்நாடு.',
+      '',
+      'லக்ஷ்மீ சோதனை: தமிழ்நாடு செய்ய்யவென்ன — உயிர்மெய் stacking.',
+      '',
+      'எண்கள்: ௧௨௩௪௫௬௭௮௯௦.'
+    ].join('\n')
+  },
+  bengali: {
+    title: 'Extreme Bengali + Devanagari',
+    heading: 'Bengali & Devanagari extreme — reph, conjuncts, matras',
+    langs: ['bn', 'hi', 'ar'],
+    body: [
+      'বাংলা stacking ও conjuncts: ক ক্ত ক্ক ক্ষ ক্ষ্ম ক্ষ্ণ ক্ল ক্ব ক্য ক্র লক্ষ্মী.',
+      '',
+      'देवनागरी stacking और conjuncts: क क्त क्क क्ष क्ष्म क्ष्ण क्ल क्व क्म क्य क्र क्लु क्ष्मी.',
+      '',
+      'BiDi mix: বাংলা ১২৩৪৫ — हिंदी ६७८९० — السلام عليكم — Hello.',
+      '',
+      'সংখ্যা: ১২৩৪৫৬৭৮৯০ — १२३४५६७८९०.'
+    ].join('\n')
+  },
+  harakat: {
+    title: 'Extreme Arabic harakat',
+    heading: 'Arabic harakat — isolated and contextual',
+    langs: ['ar'],
+    body: [
+      'بِسْمِ ٱللَّٰهِ ٱلرَّحْمَٰنِ ٱلرَّحِيمِ',
+      '',
+      'علامات التشكيل المعزولة على التطويل: ـَ ـِ ـُ ـً ـٍ ـٌ ـّ ـْ.',
+      '',
+      'مع التشكيل المركَّب: مَدَرَسَةٌ — كِتَابٌ — قَلَمٌ — طَالِبٌ — مُعَلِّمَةٌ.',
+      '',
+      'النص الكامل المركَّب: ٱلسَّلَامُ عَلَيْكُمْ وَرَحْمَةُ ٱللَّٰهِ وَبَرَكَاتُهُ.'
+    ].join('\n')
+  }
+};
+
+const FONT_MODULE_BY_LANG = {
+  ar: 'noto-arabic-data.js',
+  he: 'noto-hebrew-data.js',
+  th: 'noto-thai-data.js',
+  ta: 'noto-tamil-data.js',
+  bn: 'noto-bengali-data.js',
+  hi: 'noto-devanagari-data.js'
+};
+
+const $ = (id) => document.getElementById(id);
+const status = $('status');
+const codeView = $('code-view');
+
+function setStatus(msg, kind) {
+  status.style.display = 'block';
+  status.textContent = msg;
+  if (kind === 'error') {
+    status.style.background = '#fee2e2'; status.style.color = '#991b1b'; status.style.border = '1px solid #fca5a5';
+  } else if (kind === 'success') {
+    status.style.background = '#d1fae5'; status.style.color = '#065f46'; status.style.border = '1px solid #6ee7b7';
+  } else {
+    status.style.background = '#dbeafe'; status.style.color = '#1e3a8a'; status.style.border = '1px solid #93c5fd';
+  }
+}
+
+function applyPreset(id) {
+  const p = PRESETS[id];
+  $('title').value = p.title;
+  $('heading').value = p.heading;
+  $('body').value = p.body;
+  updateCodeView(id);
+}
+
+function updateCodeView(id) {
+  const p = PRESETS[id];
+  const code = [
+    "import { registerFonts, loadFontData, buildDocumentPDFBytes, downloadBlob } from 'pdfnative';",
+    '',
+    'registerFonts({',
+    ...p.langs.map(l => `  ${l}: () => import('https://esm.sh/pdfnative/fonts/${FONT_MODULE_BY_LANG[l]}'),`),
+    '});',
+    '',
+    `const langs = ${JSON.stringify(p.langs)};`,
+    'const fonts = await Promise.all(langs.map(loadFontData));',
+    'const fontEntries = fonts.map((fd, i) => fd ? { fontData: fd, fontRef: `/F${3+i}`, lang: langs[i] } : null).filter(Boolean);',
+    '',
+    'const pdf = buildDocumentPDFBytes({',
+    `  title: ${JSON.stringify(p.title)},`,
+    '  blocks: [',
+    `    { type: 'heading', text: ${JSON.stringify(p.heading)}, level: 1 },`,
+    ...p.body.split(/\n\s*\n/).map(par => `    { type: 'paragraph', text: ${JSON.stringify(par.trim())} },`).filter(s => !s.includes('text: ""')),
+    '  ],',
+    '  fontEntries,',
+    '});',
+    '',
+    "downloadBlob(pdf, 'extreme.pdf');"
+  ].join('\n');
+  codeView.textContent = code;
+  if (window.Prism) window.Prism.highlightElement(codeView);
+}
+
+const CDN_URLS = ['https://esm.sh/pdfnative', 'https://cdn.jsdelivr.net/npm/pdfnative/+esm'];
+let pdfMod = null;
+
+async function loadPdfnative() {
+  if (pdfMod) return pdfMod;
+  let lastErr = null;
+  for (const url of CDN_URLS) {
+    try {
+      const m = await import(url);
+      const mod = (typeof m.buildDocumentPDFBytes === 'function') ? m
+                : (m.default && typeof m.default.buildDocumentPDFBytes === 'function') ? m.default
+                : Object.assign({}, m, m.default || {});
+      if (typeof mod.buildDocumentPDFBytes === 'function') { pdfMod = mod; return mod; }
+    } catch (e) { lastErr = e; }
+  }
+  throw new Error('Could not load pdfnative from CDN. ' + (lastErr ? lastErr.message : ''));
+}
+
+async function generate() {
+  const id = $('preset').value;
+  const p = PRESETS[id];
+  const t0 = performance.now();
+  try {
+    setStatus('Loading pdfnative from CDN…', 'info');
+    const mod = await loadPdfnative();
+    setStatus('Loading fonts: ' + p.langs.join(', ') + '…', 'info');
+    const registry = {};
+    for (const lang of p.langs) {
+      registry[lang] = () => import(`https://esm.sh/pdfnative/fonts/${FONT_MODULE_BY_LANG[lang]}`);
+    }
+    mod.registerFonts(registry);
+    const fonts = await Promise.all(p.langs.map(mod.loadFontData));
+    const fontEntries = fonts.map((fd, i) => fd ? { fontData: fd, fontRef: `/F${3 + i}`, lang: p.langs[i] } : null).filter(Boolean);
+    if (fontEntries.length !== p.langs.length) {
+      throw new Error('Some fonts failed to load: expected ' + p.langs.length + ', got ' + fontEntries.length);
+    }
+    setStatus('Generating PDF…', 'info');
+    const blocks = [{ type: 'heading', text: $('heading').value, level: 1 }];
+    const body = $('body').value;
+    for (const par of body.split(/\n\s*\n/)) {
+      const t = par.trim();
+      if (t) blocks.push({ type: 'paragraph', text: t });
+    }
+    const pdf = mod.buildDocumentPDFBytes({ title: $('title').value, blocks, fontEntries });
+    mod.downloadBlob(pdf, `extreme-${id}.pdf`);
+    const ms = (performance.now() - t0).toFixed(0);
+    $('timer').textContent = `Generated ${(pdf.length / 1024).toFixed(1)} KB in ${ms} ms`;
+    setStatus('PDF generated and downloaded.', 'success');
+  } catch (err) {
+    setStatus('Error: ' + (err.message || err), 'error');
+    console.error(err);
+  }
+}
+
+$('preset').addEventListener('change', e => applyPreset(e.target.value));
+$('generate').addEventListener('click', generate);
+applyPreset('bidi');
+</script>
+</body>
+</html>

--- a/docs/playgrounds/medical-800.html
+++ b/docs/playgrounds/medical-800.html
@@ -1,0 +1,580 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Medical 800-page Worker Playground — pdfnative</title>
+  <meta name="description" content="Generate an 800-page synthetic medical report off the main thread using a Web Worker. Showcase of pdfnative streaming output, tables, headers, footers, and Tagged PDF.">
+  <link rel="canonical" href="https://pdfnative.dev/playgrounds/medical-800.html">
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+  <link rel="stylesheet" href="../style.css">
+  <link rel="stylesheet" href="../guides/guide.css">
+</head>
+<body>
+
+<nav class="nav" role="navigation" aria-label="Main navigation">
+  <div class="nav-inner">
+    <a class="nav-brand" href="../">
+      <img src="../assets/logo.svg" alt="" width="28" height="28">
+      pdfnative
+    </a>
+    <button class="nav-hamburger" aria-label="Toggle menu" aria-expanded="false">☰</button>
+    <ul class="nav-links" role="list">
+      <li><a href="../#features">Features</a></li>
+      <li><a href="../#examples">Examples</a></li>
+      <li><a href="../#demo">Demo</a></li>
+      <li><a href="./extreme-scripts.html">Extreme</a></li>
+      <li><a href="./medical-800.html" aria-current="page">Medical 800p</a></li>
+      <li><a href="../guides/">Guides</a></li>
+      <li><a href="https://github.com/Nizoka/pdfnative" target="_blank" rel="noopener">GitHub</a></li>
+      <li><button class="theme-toggle" aria-label="Toggle dark mode">🌙</button></li>
+    </ul>
+  </div>
+</nav>
+
+<main class="guide-shell">
+  <p class="guide-breadcrumb"><a href="../">Home</a> &nbsp;›&nbsp; Playgrounds &nbsp;›&nbsp; Medical 800-page</p>
+  <article class="guide-content">
+    <h1>800-page Medical Report — Web Worker Showcase</h1>
+    <p>Generates a fictitious, fully synthetic medical report (anonymized data, deterministic seeded RNG) demonstrating how pdfnative scales to large documents off the main thread. Pages contain headers, footers, patient summaries, longitudinal vital signs tables, and laboratory results — typical real-world clinical document patterns.</p>
+    <p><strong>Privacy:</strong> all patient names, IDs, dates, and values are generated client-side from a seeded random number generator. No real PHI is ever sent over the network.</p>
+
+    <div id="localWarning" style="display:none;background:#fef9c3;border:1px solid #fde047;border-radius:8px;padding:14px 16px;margin-bottom:20px;font-size:14px;line-height:1.6;">
+      <strong>⚠️ Running from <code>file://</code> — Web Worker disabled</strong><br>
+      Browsers block ESM Workers when a page is opened directly from disk (<code>file://</code> protocol)
+      because <code>file:</code> origins are treated as unique security origins and cannot load cross-origin
+      worker scripts (see <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=40487" target="_blank" rel="noopener">Chromium issue #40487</a>).<br>
+      <strong>To use the Web Worker:</strong> serve this directory with a local HTTP server:
+      <pre style="background:#fef08a;border-radius:4px;padding:8px 10px;margin:8px 0 4px;font-size:13px;">npx serve docs/
+# or: python -m http.server 8080 --directory docs/
+# then open http://localhost:5000/playgrounds/medical-800.html</pre>
+      The page is fully functional on <a href="https://pdfnative.dev/playgrounds/medical-800.html" target="_blank" rel="noopener">pdfnative.dev</a>
+      (served over HTTPS) where Web Workers work correctly.
+      <strong>Generation will automatically fall back to the main thread</strong> for this local session.
+    </div>
+
+    <div style="display:flex;gap:12px;flex-wrap:wrap;align-items:center;margin:24px 0;">
+      <label for="pageCount"><strong>Pages:</strong></label>
+      <select id="pageCount" style="padding:6px 10px;border-radius:6px;border:1px solid #cbd5e1;font-size:14px;">
+        <option value="100">100 pages — quick test</option>
+        <option value="400">400 pages — medium</option>
+        <option value="800" selected>800 pages — full showcase</option>
+      </select>
+      <label for="useWorker" style="display:flex;align-items:center;gap:6px;">
+        <input id="useWorker" type="checkbox" checked> <strong>Run in Web Worker</strong> <span id="workerNote" style="font-size:12px;color:#64748b;">(off main thread)</span>
+      </label>
+      <label for="useTagged" style="display:flex;align-items:center;gap:6px;">
+        <input id="useTagged" type="checkbox"> Tagged PDF (PDF/A-2b)
+      </label>
+      <button id="generate" class="btn btn-primary" style="padding:8px 18px;">Generate report</button>
+      <button id="cancel" class="btn btn-secondary" style="padding:8px 18px;display:none;">Cancel</button>
+    </div>
+
+    <div id="status" style="display:none;padding:12px 16px;border-radius:6px;margin-bottom:16px;font-size:14px;"></div>
+
+    <div style="background:#f1f5f9;border-radius:8px;padding:16px;margin-bottom:24px;">
+      <div style="display:flex;justify-content:space-between;font-size:14px;margin-bottom:6px;">
+        <span id="progressLabel">Idle</span>
+        <span id="progressPct">0%</span>
+      </div>
+      <div style="background:#e2e8f0;border-radius:999px;height:10px;overflow:hidden;">
+        <div id="progressBar" style="background:linear-gradient(90deg,#3b82f6,#8b5cf6);height:100%;width:0%;transition:width 0.2s;"></div>
+      </div>
+      <div style="display:grid;grid-template-columns:repeat(4,1fr);gap:12px;margin-top:14px;font-size:13px;">
+        <div><div style="color:#64748b;">Mode</div><div id="statMode" style="font-weight:600;">—</div></div>
+        <div><div style="color:#64748b;">Bytes streamed</div><div id="statBytes" style="font-weight:600;">—</div></div>
+        <div><div style="color:#64748b;">Chunks</div><div id="statChunks" style="font-weight:600;">—</div></div>
+        <div><div style="color:#64748b;">Elapsed</div><div id="statElapsed" style="font-weight:600;">—</div></div>
+      </div>
+    </div>
+
+    <h2>What this showcase demonstrates</h2>
+    <ul>
+      <li><strong>Web Worker offload</strong> — UI stays responsive while the worker generates 800 pages. Toggle the checkbox to compare with main-thread generation.</li>
+      <li><strong>Streaming output</strong> — <code>buildDocumentPDFStream</code> yields chunks as the document is built; the worker forwards them to the main thread for progressive aggregation.</li>
+      <li><strong>Long-form pagination</strong> — heading/paragraph/table block flow with automatic page breaks, headers, and footers.</li>
+      <li><strong>Synthetic data at scale</strong> — seeded RNG produces deterministic, anonymized patient cohorts, vital signs, and lab panels.</li>
+      <li><strong>Tagged PDF (optional)</strong> — enable PDF/A-2b output with full structure tree.</li>
+    </ul>
+
+    <h2>Code structure</h2>
+    <pre><code class="language-typescript">// Main thread
+const worker = new Worker(workerBlobUrl, { type: 'module' });
+worker.onmessage = (e) =&gt; {
+  if (e.data.type === 'progress') updateProgress(e.data);
+  if (e.data.type === 'done') downloadPdf(e.data.bytes);
+};
+worker.postMessage({ pageCount: 800, tagged: true, seed: 42 });
+
+// Inside the worker
+import { buildDocumentPDFStream, concatChunks } from 'https://esm.sh/pdfnative';
+const blocks = synthesizePatientReport(seed, pageCount);
+const chunks = [];
+for await (const chunk of buildDocumentPDFStream({ title, blocks }, {}, { chunkSize: 65536 })) {
+  chunks.push(chunk);
+  postMessage({ type: 'progress', bytes: chunks.reduce((s, c) =&gt; s + c.length, 0) });
+}
+postMessage({ type: 'done', bytes: concatChunks(chunks) }, [bytes.buffer]);
+</code></pre>
+
+    <p><a href="https://github.com/Nizoka/pdfnative/blob/main/docs/playgrounds/medical-800.html" target="_blank" rel="noopener">View this page&rsquo;s source on GitHub →</a></p>
+  </article>
+</main>
+
+<footer class="footer">
+  <div class="footer-inner">
+    <span>MIT License · © 2026 Nizoka</span>
+    <ul class="footer-links" role="list">
+      <li><a href="https://github.com/Nizoka/pdfnative" target="_blank" rel="noopener">GitHub</a></li>
+      <li><a href="../guides/">Guides</a></li>
+      <li><a href="./extreme-scripts.html">← Extreme scripts playground</a></li>
+    </ul>
+  </div>
+</footer>
+
+<script type="module">
+const $ = (id) => document.getElementById(id);
+const status = $('status');
+let activeWorker = null;
+
+// ── file:// detection ──────────────────────────────────────────────
+// ESM Workers loaded from Blob URLs that run `import()` of a cross-origin
+// CDN resource are blocked when the page is opened via file:// because
+// Chrome/Firefox treat file: origins as unique and reject the redirect.
+// We detect this early, show a clear explanation, and force main-thread mode.
+const IS_FILE_ORIGIN = location.protocol === 'file:';
+if (IS_FILE_ORIGIN) {
+  $('localWarning').style.display = 'block';
+  const workerCheckbox = $('useWorker');
+  workerCheckbox.checked = false;
+  workerCheckbox.disabled = true;
+  $('workerNote').textContent = '(disabled — file:// origin; serve via HTTP to enable)';
+  $('workerNote').style.color = '#b45309';
+}
+
+function setStatus(msg, kind) {
+  status.style.display = 'block';
+  status.textContent = msg;
+  if (kind === 'error') {
+    status.style.background = '#fee2e2'; status.style.color = '#991b1b'; status.style.border = '1px solid #fca5a5';
+  } else if (kind === 'success') {
+    status.style.background = '#d1fae5'; status.style.color = '#065f46'; status.style.border = '1px solid #6ee7b7';
+  } else {
+    status.style.background = '#dbeafe'; status.style.color = '#1e3a8a'; status.style.border = '1px solid #93c5fd';
+  }
+}
+function setProgress(pct, label) {
+  $('progressBar').style.width = pct + '%';
+  $('progressPct').textContent = pct.toFixed(0) + '%';
+  if (label) $('progressLabel').textContent = label;
+}
+
+// Worker source: imports pdfnative from CDN, synthesizes a medical report,
+// streams chunks back to main thread, posts progress + final PDF.
+const WORKER_SRC = `
+const CDN_URLS = ['https://esm.sh/pdfnative', 'https://cdn.jsdelivr.net/npm/pdfnative/+esm'];
+
+async function loadPdfnative() {
+  let lastErr = null;
+  for (const url of CDN_URLS) {
+    try {
+      const m = await import(url);
+      const mod = (typeof m.buildDocumentPDFStream === 'function') ? m
+                : (m.default && typeof m.default.buildDocumentPDFStream === 'function') ? m.default
+                : Object.assign({}, m, m.default || {});
+      if (typeof mod.buildDocumentPDFStream === 'function') return mod;
+    } catch (e) { lastErr = e; }
+  }
+  throw new Error('Failed to load pdfnative: ' + (lastErr ? lastErr.message : ''));
+}
+
+// ── Seeded RNG (Mulberry32) for deterministic synthetic data ───────
+function rng(seed) {
+  let s = seed >>> 0;
+  return () => {
+    s = (s + 0x6D2B79F5) >>> 0;
+    let t = s;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const FIRST = ['Aaron','Beatrice','Carlos','Dominique','Elena','Frédéric','Gabriela','Hiroshi','Ines','Jamal','Kira','Liam','Marie','Noa','Omar','Priya','Quentin','Rania','Sven','Tara','Ursula','Victor','Wei','Xiomara','Yusuf','Zoé'];
+const LAST = ['Adler','Bianchi','Costa','Dubois','Edelman','Fournier','Garcia','Haddad','Iyer','Jensen','Khan','Lopez','Martín','Nakamura','Okafor','Petrov','Quintero','Rossi','Smith','Tanaka','Ulrich','Vasquez','Wang','Yamamoto','Zhao'];
+const DIAG = ['Hypertension','Type 2 diabetes','Asthma','Hypercholesterolemia','Migraine','Hypothyroidism','Anemia (iron deficiency)','GERD','Osteoarthritis','Allergic rhinitis','Vitamin D deficiency','Chronic sinusitis'];
+const MEDS = ['Lisinopril 10 mg','Metformin 500 mg','Atorvastatin 20 mg','Levothyroxine 50 mcg','Albuterol 90 mcg','Sumatriptan 50 mg','Omeprazole 20 mg','Ferrous sulfate 325 mg','Ibuprofen 400 mg','Loratadine 10 mg','Cetirizine 10 mg','Vitamin D3 2000 IU'];
+const ALLERGIES = ['NKDA','Penicillin','Sulfa drugs','Latex','Peanuts','Shellfish','Aspirin','Iodine contrast'];
+const STATUS = ['Stable','Improving','Resolved','Ongoing','Monitored'];
+
+function patient(r, i) {
+  const fn = FIRST[Math.floor(r() * FIRST.length)];
+  const ln = LAST[Math.floor(r() * LAST.length)];
+  const age = 18 + Math.floor(r() * 70);
+  const sex = r() < 0.5 ? 'F' : 'M';
+  const id = 'PT-' + String(100000 + i).padStart(6, '0');
+  return { id, name: fn + ' ' + ln, age, sex };
+}
+
+function vitals(r, n) {
+  const rows = [];
+  for (let i = 0; i < n; i++) {
+    const day = String(1 + Math.floor(r() * 28)).padStart(2, '0');
+    const month = String(1 + Math.floor(r() * 12)).padStart(2, '0');
+    const sysBP = 100 + Math.floor(r() * 50);
+    const diaBP = 60 + Math.floor(r() * 30);
+    const hr = 55 + Math.floor(r() * 40);
+    const temp = (36.0 + r() * 1.8).toFixed(1);
+    const spo2 = (94 + Math.floor(r() * 6));
+    rows.push({ cells: [
+      \`2026-\${month}-\${day}\`,
+      \`\${sysBP}/\${diaBP} mmHg\`,
+      \`\${hr} bpm\`,
+      \`\${temp} °C\`,
+      \`\${spo2}%\`,
+    ]});
+  }
+  return rows;
+}
+
+function labs(r, n) {
+  const tests = [
+    ['Glucose', 70, 110, 'mg/dL'],
+    ['HbA1c', 4.5, 7.0, '%'],
+    ['Total cholesterol', 130, 240, 'mg/dL'],
+    ['HDL', 35, 80, 'mg/dL'],
+    ['LDL', 70, 180, 'mg/dL'],
+    ['Triglycerides', 50, 250, 'mg/dL'],
+    ['Creatinine', 0.6, 1.4, 'mg/dL'],
+    ['eGFR', 60, 120, 'mL/min'],
+    ['ALT', 7, 56, 'U/L'],
+    ['AST', 10, 40, 'U/L'],
+    ['Hemoglobin', 11, 17, 'g/dL'],
+    ['WBC', 3.5, 11.0, 'K/µL'],
+    ['Platelets', 150, 400, 'K/µL'],
+    ['TSH', 0.4, 4.5, 'mIU/L'],
+    ['Vitamin D', 20, 80, 'ng/mL'],
+  ];
+  const rows = [];
+  for (let i = 0; i < Math.min(n, tests.length); i++) {
+    const [name, lo, hi, unit] = tests[i];
+    const range = hi - lo;
+    const val = lo + r() * range * 1.4 - range * 0.2;
+    const fixed = val.toFixed(name === 'HbA1c' || name === 'Creatinine' ? 1 : 0);
+    const flag = (val < lo) ? 'L' : (val > hi) ? 'H' : '';
+    rows.push({ cells: [name, fixed, unit, \`\${lo}–\${hi}\`, flag] });
+  }
+  return rows;
+}
+
+function buildBlocks(seed, pageCount) {
+  const r = rng(seed);
+  // Calibrated for ~4 pages per patient (measured empirically).
+  // 800 pages → 200 patients · 400 → 100 · 100 → 25.
+  const patientCount = Math.max(1, Math.floor(pageCount / 4));
+  const blocks = [];
+
+  blocks.push({ type: 'heading', text: 'Synthetic Clinical Data Report (FICTITIOUS)', level: 1 });
+  blocks.push({ type: 'paragraph', text: 'This document is generated programmatically from a seeded random-number generator for demonstration purposes only. All patient identifiers, names, dates, and values are synthetic. No real Protected Health Information (PHI) is contained.' });
+  blocks.push({ type: 'paragraph', text: \`Cohort size: \${patientCount} patients · Target page count: \${pageCount} · Seed: \${seed}.\` });
+
+  const FINDINGS = [
+    'Patient presents in no acute distress. Vital signs within expected range for chronic conditions.',
+    'Mild fatigue reported over the last two weeks; sleep hygiene counseling provided.',
+    'Mild peripheral edema noted bilaterally; lower extremity examination otherwise unremarkable.',
+    'No new musculoskeletal complaints. Range of motion preserved across all major joints.',
+    'Auscultation reveals clear lung fields bilaterally; cardiac rhythm regular without murmurs.',
+    'Patient reports adequate medication adherence; no adverse effects since last visit.',
+    'Mild seasonal allergic symptoms; antihistamines have provided adequate relief.',
+    'Routine well-visit; no acute concerns identified during interval since last encounter.'
+  ];
+  const PLANS = [
+    'Continue current pharmacological regimen. Reinforce dietary counseling. Re-evaluate in three months.',
+    'Adjust dosage upward by one increment. Order follow-up labs in six weeks. Monitor for side effects.',
+    'Add lifestyle modification component (exercise 150 min/week, sodium <2 g/day). Recheck in one month.',
+    'Order imaging (chest X-ray, abdominal ultrasound) to characterize incidental finding. Specialist referral pending results.',
+    'No changes to current management. Patient reports improvement; continue maintenance therapy.',
+    'Initiate annual screening per USPSTF guidelines. Update vaccination status. Schedule next preventive visit.'
+  ];
+
+  for (let p = 0; p < patientCount; p++) {
+    const pt = patient(r, p);
+    blocks.push({ type: 'heading', text: \`Patient \${pt.id} — \${pt.name}\`, level: 2 });
+    blocks.push({ type: 'paragraph', text: \`Age: \${pt.age} · Sex: \${pt.sex} · Allergies: \${ALLERGIES[Math.floor(r() * ALLERGIES.length)]}\` });
+
+    blocks.push({ type: 'heading', text: 'Active diagnoses', level: 3 });
+    const dxCount = 2 + Math.floor(r() * 3);
+    const dxs = [];
+    for (let i = 0; i < dxCount; i++) dxs.push(\`\${DIAG[Math.floor(r() * DIAG.length)]} — \${STATUS[Math.floor(r() * STATUS.length)]}\`);
+    blocks.push({ type: 'list', items: dxs, style: 'bullet' });
+
+    blocks.push({ type: 'heading', text: 'Current medications', level: 3 });
+    const medCount = 2 + Math.floor(r() * 4);
+    const meds = [];
+    for (let i = 0; i < medCount; i++) meds.push(MEDS[Math.floor(r() * MEDS.length)]);
+    blocks.push({ type: 'list', items: meds, style: 'bullet' });
+
+    // Six longitudinal clinical visits — drives ~0.67 pages each on average.
+    for (let v = 1; v <= 6; v++) {
+      const month = String(1 + Math.floor(r() * 12)).padStart(2, '0');
+      const day = String(1 + Math.floor(r() * 28)).padStart(2, '0');
+      blocks.push({ type: 'heading', text: \`Visit \${v} — 2026-\${month}-\${day}\`, level: 3 });
+      blocks.push({ type: 'paragraph', text: 'Clinical findings: ' + FINDINGS[Math.floor(r() * FINDINGS.length)] });
+      blocks.push({
+        type: 'table',
+        headers: ['Time', 'Blood pressure', 'Heart rate', 'Temperature', 'SpO2'],
+        rows: vitals(r, 8),
+      });
+      blocks.push({
+        type: 'table',
+        headers: ['Test', 'Value', 'Unit', 'Reference range', 'Flag'],
+        rows: labs(r, 15),
+      });
+      blocks.push({ type: 'paragraph', text: 'Assessment & plan: ' + PLANS[Math.floor(r() * PLANS.length)] });
+    }
+  }
+  return blocks;
+}
+
+self.addEventListener('message', async (ev) => {
+  const { pageCount, tagged, seed } = ev.data;
+  try {
+    const mod = await loadPdfnative();
+    const blocks = buildBlocks(seed, pageCount);
+    const params = {
+      title: 'Synthetic Clinical Data Report',
+      blocks,
+      footerText: 'Synthetic / FICTITIOUS — generated by pdfnative.dev playground',
+    };
+    const layoutOptions = tagged ? { tagged: true } : {};
+    const chunks = [];
+    let totalBytes = 0;
+    let count = 0;
+    const t0 = Date.now();
+    for await (const chunk of mod.buildDocumentPDFStream(params, layoutOptions, { chunkSize: 65536 })) {
+      chunks.push(chunk);
+      totalBytes += chunk.length;
+      count++;
+      if (count % 5 === 0) postMessage({ type: 'progress', bytes: totalBytes, chunks: count, elapsed: Date.now() - t0 });
+    }
+    const pdf = mod.concatChunks(chunks);
+    postMessage({ type: 'done', bytes: pdf, elapsed: Date.now() - t0, chunks: count }, [pdf.buffer]);
+  } catch (err) {
+    postMessage({ type: 'error', message: err.message || String(err) });
+  }
+});
+`;
+
+function downloadPdf(bytes, filename) {
+  const blob = new Blob([bytes], { type: 'application/pdf' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url; a.download = filename; a.click();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+async function generateInWorker(pageCount, tagged) {
+  return new Promise((resolve, reject) => {
+    const blob = new Blob([WORKER_SRC], { type: 'application/javascript' });
+    const url = URL.createObjectURL(blob);
+    const w = new Worker(url, { type: 'module' });
+    activeWorker = w;
+    URL.revokeObjectURL(url);
+    w.onmessage = (e) => {
+      if (e.data.type === 'progress') {
+        const targetBytes = pageCount * 15000; // ~15 KB/page average for the medical layout
+        const pct = Math.min(95, (e.data.bytes / targetBytes) * 100);
+        setProgress(pct, `Streaming chunk ${e.data.chunks}…`);
+        $('statBytes').textContent = (e.data.bytes / 1024).toFixed(1) + ' KB';
+        $('statChunks').textContent = String(e.data.chunks);
+        $('statElapsed').textContent = (e.data.elapsed / 1000).toFixed(1) + ' s';
+      } else if (e.data.type === 'done') {
+        setProgress(100, 'Complete');
+        $('statBytes').textContent = (e.data.bytes.length / 1024).toFixed(1) + ' KB';
+        $('statChunks').textContent = String(e.data.chunks);
+        $('statElapsed').textContent = (e.data.elapsed / 1000).toFixed(1) + ' s';
+        w.terminate();
+        activeWorker = null;
+        resolve(e.data.bytes);
+      } else if (e.data.type === 'error') {
+        w.terminate();
+        activeWorker = null;
+        reject(new Error(e.data.message));
+      }
+    };
+    w.onerror = (e) => { w.terminate(); activeWorker = null; reject(new Error(e.message || 'Worker error')); };
+    w.postMessage({ pageCount, tagged, seed: 42 });
+  });
+}
+
+const CDN_URLS = ['https://esm.sh/pdfnative', 'https://cdn.jsdelivr.net/npm/pdfnative/+esm'];
+let mainMod = null;
+async function loadPdfnativeMain() {
+  if (mainMod) return mainMod;
+  let lastErr = null;
+  for (const url of CDN_URLS) {
+    try {
+      const m = await import(url);
+      const mod = (typeof m.buildDocumentPDFStream === 'function') ? m
+                : (m.default && typeof m.default.buildDocumentPDFStream === 'function') ? m.default
+                : Object.assign({}, m, m.default || {});
+      if (typeof mod.buildDocumentPDFStream === 'function') { mainMod = mod; return mod; }
+    } catch (e) { lastErr = e; }
+  }
+  throw new Error('Failed to load pdfnative: ' + (lastErr ? lastErr.message : ''));
+}
+
+async function generateOnMain(pageCount, tagged) {
+  const mod = await loadPdfnativeMain();
+  // Reuse the same data shape as the worker (full longitudinal cohort, ~5 pages per patient).
+  // Mirrors WORKER_SRC.buildBlocks exactly so the page count is consistent across modes.
+  const FIRST = ['Aaron','Beatrice','Carlos','Dominique','Elena','Frédéric','Gabriela','Hiroshi','Ines','Jamal','Kira','Liam','Marie','Noa','Omar','Priya','Quentin','Rania','Sven','Tara','Ursula','Victor','Wei','Xiomara','Yusuf','Zoé'];
+  const LAST = ['Adler','Bianchi','Costa','Dubois','Edelman','Fournier','Garcia','Haddad','Iyer','Jensen','Khan','Lopez','Martín','Nakamura','Okafor','Petrov','Quintero','Rossi','Smith','Tanaka','Ulrich','Vasquez','Wang','Yamamoto','Zhao'];
+  const DIAG = ['Hypertension','Type 2 diabetes','Asthma','Hypercholesterolemia','Migraine','Hypothyroidism','Anemia (iron deficiency)','GERD','Osteoarthritis','Allergic rhinitis','Vitamin D deficiency','Chronic sinusitis'];
+  const MEDS = ['Lisinopril 10 mg','Metformin 500 mg','Atorvastatin 20 mg','Levothyroxine 50 mcg','Albuterol 90 mcg','Sumatriptan 50 mg','Omeprazole 20 mg','Ferrous sulfate 325 mg','Ibuprofen 400 mg','Loratadine 10 mg','Cetirizine 10 mg','Vitamin D3 2000 IU'];
+  const ALLERGIES = ['NKDA','Penicillin','Sulfa drugs','Latex','Peanuts','Shellfish','Aspirin','Iodine contrast'];
+  const STATUS = ['Stable','Improving','Resolved','Ongoing','Monitored'];
+  const FINDINGS = [
+    'Patient presents in no acute distress. Vital signs within expected range for chronic conditions.',
+    'Mild fatigue reported over the last two weeks; sleep hygiene counseling provided.',
+    'Mild peripheral edema noted bilaterally; lower extremity examination otherwise unremarkable.',
+    'No new musculoskeletal complaints. Range of motion preserved across all major joints.',
+    'Auscultation reveals clear lung fields bilaterally; cardiac rhythm regular without murmurs.',
+    'Patient reports adequate medication adherence; no adverse effects since last visit.',
+    'Mild seasonal allergic symptoms; antihistamines have provided adequate relief.',
+    'Routine well-visit; no acute concerns identified during interval since last encounter.'
+  ];
+  const PLANS = [
+    'Continue current pharmacological regimen. Reinforce dietary counseling. Re-evaluate in three months.',
+    'Adjust dosage upward by one increment. Order follow-up labs in six weeks. Monitor for side effects.',
+    'Add lifestyle modification component (exercise 150 min/week, sodium <2 g/day). Recheck in one month.',
+    'Order imaging (chest X-ray, abdominal ultrasound) to characterize incidental finding. Specialist referral pending results.',
+    'No changes to current management. Patient reports improvement; continue maintenance therapy.',
+    'Initiate annual screening per USPSTF guidelines. Update vaccination status. Schedule next preventive visit.'
+  ];
+  const r = (() => { let s = 42 >>> 0; return () => { s = (s + 0x6D2B79F5) >>> 0; let t = s; t = Math.imul(t ^ (t >>> 15), t | 1); t ^= t + Math.imul(t ^ (t >>> 7), t | 61); return ((t ^ (t >>> 14)) >>> 0) / 4294967296; }; })();
+  const vitalsRows = (n) => {
+    const rows = [];
+    for (let i = 0; i < n; i++) {
+      const day = String(1 + Math.floor(r() * 28)).padStart(2, '0');
+      const month = String(1 + Math.floor(r() * 12)).padStart(2, '0');
+      rows.push({ cells: [
+        `2026-${month}-${day}`,
+        `${100 + Math.floor(r() * 50)}/${60 + Math.floor(r() * 30)} mmHg`,
+        `${55 + Math.floor(r() * 40)} bpm`,
+        `${(36.0 + r() * 1.8).toFixed(1)} °C`,
+        `${94 + Math.floor(r() * 6)}%`,
+      ]});
+    }
+    return rows;
+  };
+  const labTests = [
+    ['Glucose', 70, 110, 'mg/dL'], ['HbA1c', 4.5, 7.0, '%'], ['Total cholesterol', 130, 240, 'mg/dL'],
+    ['HDL', 35, 80, 'mg/dL'], ['LDL', 70, 180, 'mg/dL'], ['Triglycerides', 50, 250, 'mg/dL'],
+    ['Creatinine', 0.6, 1.4, 'mg/dL'], ['eGFR', 60, 120, 'mL/min'], ['ALT', 7, 56, 'U/L'],
+    ['AST', 10, 40, 'U/L'], ['Hemoglobin', 11, 17, 'g/dL'], ['WBC', 3.5, 11.0, 'K/uL'],
+    ['Platelets', 150, 400, 'K/uL'], ['TSH', 0.4, 4.5, 'mIU/L'], ['Vitamin D', 20, 80, 'ng/mL'],
+  ];
+  const labRows = (n) => {
+    const rows = [];
+    for (let i = 0; i < Math.min(n, labTests.length); i++) {
+      const [name, lo, hi, unit] = labTests[i];
+      const range = hi - lo;
+      const val = lo + r() * range * 1.4 - range * 0.2;
+      const fixed = val.toFixed(name === 'HbA1c' || name === 'Creatinine' ? 1 : 0);
+      const flag = (val < lo) ? 'L' : (val > hi) ? 'H' : '';
+      rows.push({ cells: [name, fixed, unit, `${lo}–${hi}`, flag] });
+    }
+    return rows;
+  };
+
+  const patientCount = Math.max(1, Math.floor(pageCount / 4));
+  const blocks = [
+    { type: 'heading', text: 'Synthetic Clinical Data Report (FICTITIOUS)', level: 1 },
+    { type: 'paragraph', text: 'This document is generated programmatically from a seeded random-number generator for demonstration purposes only. All patient identifiers, names, dates, and values are synthetic. No real Protected Health Information (PHI) is contained.' },
+    { type: 'paragraph', text: `Cohort size: ${patientCount} patients · Target page count: ${pageCount} · Seed: 42 · (Main-thread mode.)` },
+  ];
+  for (let p = 0; p < patientCount; p++) {
+    const fn = FIRST[Math.floor(r() * FIRST.length)];
+    const ln = LAST[Math.floor(r() * LAST.length)];
+    const id = 'PT-' + String(100000 + p).padStart(6, '0');
+    blocks.push({ type: 'heading', text: `Patient ${id} — ${fn} ${ln}`, level: 2 });
+    blocks.push({ type: 'paragraph', text: `Age: ${18 + Math.floor(r()*70)} · Sex: ${r()<0.5?'F':'M'} · Allergies: ${ALLERGIES[Math.floor(r() * ALLERGIES.length)]}` });
+
+    blocks.push({ type: 'heading', text: 'Active diagnoses', level: 3 });
+    const dxs = [];
+    for (let i = 0, n = 2 + Math.floor(r() * 3); i < n; i++) dxs.push(`${DIAG[Math.floor(r() * DIAG.length)]} — ${STATUS[Math.floor(r() * STATUS.length)]}`);
+    blocks.push({ type: 'list', items: dxs, style: 'bullet' });
+
+    blocks.push({ type: 'heading', text: 'Current medications', level: 3 });
+    const meds = [];
+    for (let i = 0, n = 2 + Math.floor(r() * 4); i < n; i++) meds.push(MEDS[Math.floor(r() * MEDS.length)]);
+    blocks.push({ type: 'list', items: meds, style: 'bullet' });
+
+    for (let v = 1; v <= 6; v++) {
+      const month = String(1 + Math.floor(r() * 12)).padStart(2, '0');
+      const day = String(1 + Math.floor(r() * 28)).padStart(2, '0');
+      blocks.push({ type: 'heading', text: `Visit ${v} — 2026-${month}-${day}`, level: 3 });
+      blocks.push({ type: 'paragraph', text: 'Clinical findings: ' + FINDINGS[Math.floor(r() * FINDINGS.length)] });
+      blocks.push({ type: 'table', headers: ['Time', 'Blood pressure', 'Heart rate', 'Temperature', 'SpO2'], rows: vitalsRows(8) });
+      blocks.push({ type: 'table', headers: ['Test', 'Value', 'Unit', 'Reference range', 'Flag'], rows: labRows(15) });
+      blocks.push({ type: 'paragraph', text: 'Assessment & plan: ' + PLANS[Math.floor(r() * PLANS.length)] });
+    }
+  }
+
+  const chunks = [];
+  let totalBytes = 0; let count = 0;
+  const t0 = performance.now();
+  for await (const chunk of mod.buildDocumentPDFStream({ title: 'Synthetic Clinical Data Report', blocks, footerText: 'Synthetic / FICTITIOUS — pdfnative.dev' }, tagged ? { tagged: true } : {}, { chunkSize: 65536 })) {
+    chunks.push(chunk);
+    totalBytes += chunk.length;
+    count++;
+    if (count % 5 === 0) {
+      const targetBytes = pageCount * 15000;
+      setProgress(Math.min(95, (totalBytes / targetBytes) * 100), `Streaming chunk ${count}… (main thread)`);
+      $('statBytes').textContent = (totalBytes / 1024).toFixed(1) + ' KB';
+      $('statChunks').textContent = String(count);
+      $('statElapsed').textContent = ((performance.now() - t0) / 1000).toFixed(1) + ' s';
+      // Yield to UI
+      await new Promise(r => setTimeout(r, 0));
+    }
+  }
+  return mod.concatChunks(chunks);
+}
+
+$('generate').addEventListener('click', async () => {
+  const pageCount = parseInt($('pageCount').value, 10);
+  const useWorker = $('useWorker').checked;
+  const tagged = $('useTagged').checked;
+  $('generate').disabled = true;
+  $('cancel').style.display = 'inline-block';
+  $('statMode').textContent = useWorker ? 'Web Worker' : 'Main thread';
+  $('statBytes').textContent = '0 KB';
+  $('statChunks').textContent = '0';
+  $('statElapsed').textContent = '0.0 s';
+  setStatus(useWorker ? 'Spawning worker, loading pdfnative from CDN…' : 'Generating on main thread…', 'info');
+  setProgress(2, 'Initializing…');
+  try {
+    const t0 = performance.now();
+    const pdf = useWorker ? await generateInWorker(pageCount, tagged) : await generateOnMain(pageCount, tagged);
+    const elapsed = (performance.now() - t0) / 1000;
+    setProgress(100, 'Complete');
+    setStatus(`Generated ${(pdf.length / 1024 / 1024).toFixed(2)} MB PDF in ${elapsed.toFixed(1)} s.`, 'success');
+    downloadPdf(pdf, `medical-${pageCount}p.pdf`);
+  } catch (err) {
+    setStatus('Error: ' + (err.message || err), 'error');
+    console.error(err);
+  } finally {
+    $('generate').disabled = false;
+    $('cancel').style.display = 'none';
+  }
+});
+
+$('cancel').addEventListener('click', () => {
+  if (activeWorker) { activeWorker.terminate(); activeWorker = null; setStatus('Cancelled.', 'error'); }
+  $('generate').disabled = false;
+  $('cancel').style.display = 'none';
+});
+</script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdfnative",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Zero-dependency native PDF generation library. 16 scripts (Arabic, Hebrew, Thai, CJK, Devanagari, Bengali, Tamil, Cyrillic, Greek, Georgian, Armenian, Latin), BiDi, PDF/A-1b/2b/3b, AES encryption, digital signatures, AcroForm, barcodes, SVG. Pure JavaScript ISO 32000-1 implementation.",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -55,7 +55,8 @@
     "typecheck:scripts": "tsc --project tsconfig.scripts.json --noEmit",
     "typecheck:all": "npm run typecheck && npm run typecheck:tests && npm run typecheck:scripts",
     "bench": "vitest bench",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "docs:serve": "npx serve docs/ --listen 5000"
   },
   "keywords": [
     "pdf",

--- a/release-notes/v1.0.3.md
+++ b/release-notes/v1.0.3.md
@@ -1,0 +1,142 @@
+# pdfnative v1.0.3
+
+<!-- GitHub Release title: v1.0.3 — extreme-script regression baseline, layout fix, playgrounds -->
+
+_Released 2026-04-25_
+
+Patch release adding extreme-script visual regression baselines, fixing a heading layout overflow on long compound titles, and shipping two new interactive playgrounds. No public API change — fully backward-compatible with v1.0.2.
+
+## Highlights
+
+- **Heading overflow fix** — long titles such as
+  `"Test Bengali + Devanagari ULTRA EXTREME — Shaping & Positioning — pdfnative"`
+  no longer overflow the right margin; `wrapText()` now hard-breaks single
+  overlong tokens at character boundaries when no whitespace breakpoint
+  exists.
+- **Extreme shaping samples** — four new visual baselines under
+  `test-output/extreme/` covering BiDi (Arabic + Hebrew + Thai + Latin +
+  digits), Tamil ultra-conjuncts, Bengali + Devanagari reph + multi-halant
+  ligature chains, and isolated Arabic harakat.
+- **Two new playgrounds** — `extreme-scripts.html` for live shaping
+  stress-tests with editable presets, and `medical-800.html` showcasing
+  off-thread generation of an 800-page synthetic clinical report via Web
+  Worker + `buildDocumentPDFStream`.
+- **Honest scoping** — deeper shaping issues exposed by the new baselines
+  (Arabic isolated harakat anchoring, Thai mark stacking on tall
+  consonants, multi-stage Indic ligature chains, 3+ RTL-script BiDi) are
+  documented as known limitations and tracked for the v1.1.0 minor
+  release. They require GPOS table re-extraction in the pre-built font
+  data modules and exceed the scope of a SemVer-patch.
+
+## Fixed
+
+- **fix(core/layout):** `wrapText()` now hard-breaks single overlong
+  tokens at character boundaries when no whitespace breakpoint exists.
+  Long headings and titles previously could overflow the right margin
+  when no segment fit. Code points are honored so surrogate pairs and
+  combining sequences remain intact at slice boundaries.
+  ([src/core/pdf-renderers.ts](../src/core/pdf-renderers.ts))
+- **fix(docs):** `guides/architecture.html` and `guides/faq.html` footer
+  links from `docs/index.html` previously 404'd because only `.md` files
+  existed under `docs/guides/` and `.nojekyll` disables auto-rendering.
+  Each guide now ships as a real HTML page with a clean URL.
+
+## Added
+
+- **feat(samples):** new `extreme-shaping.ts` generator producing four
+  visual-regression baselines under `test-output/extreme/`:
+  `extreme-bidi.pdf`, `extreme-tamil.pdf`,
+  `extreme-bengali-devanagari.pdf`, `extreme-arabic-harakat.pdf`.
+  Wired into `scripts/generate-samples.ts`.
+- **test(integration):** `tests/integration/extreme-shaping.test.ts` —
+  five end-to-end builds covering the same extreme inputs to guard
+  against pipeline regressions (1 605 tests total, up from 1 600).
+- **test(core):** new regression tests for `wrapText` confirming
+  character-level hard-break of overlong tokens and multi-line wrapping
+  of long em-dash titles.
+- **docs(playgrounds):** new interactive playground
+  `docs/playgrounds/extreme-scripts.html` for stress-testing BiDi, Tamil
+  conjuncts, Bengali + Devanagari ligatures, and Arabic harakat directly
+  in the browser, with editable presets and a code preview.
+- **docs(playgrounds):** new `docs/playgrounds/medical-800.html` — Web
+  Worker showcase generating an 800-page synthetic clinical report using
+  `buildDocumentPDFStream`, with live progress, byte/chunk counters,
+  optional Tagged PDF (PDF/A-2b), and a main-thread comparison toggle.
+  All patient data is generated client-side from a seeded RNG — no real
+  PHI.
+- **docs(landing):** static HTML guide pages (`quickstart.html`,
+  `architecture.html`, `faq.html`, `troubleshooting.html`,
+  `accessibility.html`) plus a guides index at `/guides/`.
+- **docs(guides):** new `quickstart.md` covering Node.js, browser,
+  multi-language, Web Worker, and streaming setups in a single page; new
+  `accessibility.md` covering tagged PDF, PDF/UA, PDF/A variants,
+  structure tree contents, alt-text discipline, and validation tooling.
+  Rewrote `faq.md` with sectioned topics and ten concrete code snippets.
+- **docs(readme):** added a "Documentation" pointer block linking to the
+  guides and to `pdfnative.dev`. Added Indic document samples
+  (`doc-bengali`, `doc-tamil`, `doc-devanagari`) to the Document Builder
+  Samples table. Added a "Citing pdfnative" section with BibTeX pointing
+  to `CITATION.cff`.
+
+## Changed
+
+- **docs(landing):** added project-status badges to the `pdfnative.dev`
+  hero (CI, CodeQL, OpenSSF Scorecard, npm version, monthly downloads,
+  bundle size, zero deps, TypeScript strict, npm provenance, MIT) to
+  mirror the README and surface supply-chain signals upfront.
+- **docs(landing):** rebuilt the "Try It Live" panel as a curated
+  10-example gallery (Quick Start, Financial, TOC, Barcode, SVG,
+  Watermark, Forms, PDF/A, Multi-language with lazy fonts, Streaming).
+  The runtime now supports top-level `await`, dynamic `import(…)`, and
+  exposes `streamDocumentPdf`, `registerFonts`, `loadFontData`, and
+  `signPdfBytes`.
+- **docs(landing):** added "Guides" and "Playgrounds" entries in the
+  navbar and refreshed the footer with direct links to every guide and
+  both new playgrounds.
+- **docs(landing):** synced the test counter to 1 605+ tests.
+
+## Known limitations (tracked for v1.1.0)
+
+The new extreme samples surface deeper shaping issues that are tracked
+for the next minor release. They require either GPOS table re-extraction
+in the pre-built font data modules under `fonts/` or new OpenType lookup
+implementations in the shaping pipeline, which exceed the scope of a
+SemVer-patch:
+
+- **Arabic isolated harakat:** `تشكيل` without a base consonant fall back
+  to default mark positioning rather than precise font-anchored
+  placement. Visible in `extreme-arabic-harakat.pdf`.
+- **Thai tall-consonant mark stacking:** ป ฝ ฟ ฬ with three or more
+  combining marks may overlap with the current font anchor data.
+- **Multi-stage Indic ligatures:** ক্ষ্ম, क्ष्म, ஸ்ரீ are matched
+  greedily; some deeply-nested sequences fall back to non-ligated forms.
+- **3+ script BiDi paragraphs:** Arabic + Hebrew + Thai + Latin + digits
+  in one paragraph may exhibit non-canonical run ordering at boundaries
+  with neutrals.
+
+The full follow-up plan is tracked in
+[release-notes/draft-issue-v1.1.0-shaping-epic.md](draft-issue-v1.1.0-shaping-epic.md).
+
+## Install
+
+```bash
+npm install pdfnative@1.0.3
+```
+
+## Upgrade
+
+No breaking changes. Drop-in replacement for v1.0.2.
+
+The only behavioral change is `wrapText()`, which now hard-breaks
+overlong tokens that previously overflowed the page. Existing layouts
+that relied on overflow behavior (none expected — overflow was always
+visually broken) should re-render with proper wrapping.
+
+## Links
+
+- [CHANGELOG](../CHANGELOG.md)
+- [Full diff](https://github.com/Nizoka/pdfnative/compare/v1.0.2...v1.0.3)
+- [Roadmap](../ROADMAP.md)
+- [Release notes template](TEMPLATE.md)
+- [v1.0.3 GitHub release issue draft](draft-issue-v1.0.3-release.md)
+- [v1.1.0 epic tracking issue draft](draft-issue-v1.1.0-shaping-epic.md)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -49,6 +49,7 @@ scripts/
     ├── font-subsetting-deep.ts  #  2 PDFs – TTF subsetting, CIDFont glyph mapping
     ├── parser-deep.ts           #  2 PDFs – tokenizer, xref parsing, incremental save
     └── stress-edge.ts           # 13 PDFs – 10K rows, BiDi, heavy text, images, annotations, edge cases
+    └── extreme-shaping.ts       #  4 PDFs – BiDi 3-script mix, Tamil conjuncts, Bengali+Devanagari ligatures, Arabic harakat
 ```
 
 ## How It Works

--- a/scripts/generate-samples.ts
+++ b/scripts/generate-samples.ts
@@ -35,6 +35,7 @@ import { generate as generateBidi } from './generators/bidi-algorithm.js';
 import { generate as generateCrypto } from './generators/crypto-showcase.js';
 import { generate as generateFontSubsetting } from './generators/font-subsetting-deep.js';
 import { generate as generateParserDeep } from './generators/parser-deep.js';
+import { generate as generateExtremeShaping } from './generators/extreme-shaping.js';
 
 async function generateAll(): Promise<void> {
     registerAllFonts();
@@ -110,6 +111,9 @@ async function generateAll(): Promise<void> {
 
     // ── Parser deep-dive (tokenizer, xref, /Prev chain) ────────
     await generateParserDeep(ctx);
+
+    // ── Extreme-script shaping (BiDi, Tamil, Bengali+Devanagari, Arabic harakat) ─
+    await generateExtremeShaping(ctx);
 
     // ── Summary ──────────────────────────────────────────────────
     printSummary(ctx.results, ctx.outputDir);

--- a/scripts/generators/extreme-shaping.ts
+++ b/scripts/generators/extreme-shaping.ts
@@ -1,0 +1,142 @@
+/**
+ * Extreme-script shaping samples — visual regression baseline.
+ *
+ * These samples exercise the most demanding cases for our text-shaping
+ * pipeline: deep BiDi mixing across 3+ scripts, complex Indic conjuncts
+ * with reph + multi-halant chains, isolated Arabic harakat, and Thai
+ * mark stacking on tall consonants. They serve both as showcase PDFs
+ * (test-output/extreme/) and as regression anchors when shaping rules
+ * evolve.
+ *
+ * Output: test-output/extreme/*.pdf
+ */
+
+import { resolve } from 'path';
+import { buildDocumentPDFBytes } from '../../src/index.js';
+import type { DocumentParams } from '../../src/index.js';
+import type { GenerateContext } from '../helpers/io.js';
+import { loadSelectedFontEntries } from '../helpers/fonts.js';
+
+export async function generate(ctx: GenerateContext): Promise<void> {
+    // ── 1. Extreme BiDi: Arabic + Hebrew + Thai + Latin + digits ─
+    {
+        const fontEntries = await loadSelectedFontEntries(['ar', 'he', 'th']);
+        if (fontEntries.length === 3) {
+            const params: DocumentParams = {
+                title: 'Extreme BiDi — Arabic + Hebrew + Thai + Latin',
+                blocks: [
+                    { type: 'heading', text: 'Extreme BiDi — Arabic + Hebrew + Thai + Latin + Numerals', level: 1 },
+                    { type: 'paragraph', text: 'Multi-script bidirectional paragraph with Arabic, Hebrew, Thai, Latin, and ASCII digits. The UAX #9 simplified implementation must resolve paragraph level, weak/neutral types, and reorder runs while preserving punctuation affinity and bracket pairing.' },
+
+                    { type: 'heading', text: 'Arabic shaping with diacritics', level: 2 },
+                    { type: 'paragraph', text: 'هذا اختبار للـ shaping المتقدم في اللغة العربية: السلام عليكم ورحمة الله وبركاته. النص يحتوي على حروف متصلة ومفصولة. اختبار الـ ligatures: لا إله إلا الله محمد رسول الله.' },
+
+                    { type: 'heading', text: 'Hebrew with niqqud', level: 2 },
+                    { type: 'paragraph', text: 'בדיקה של טקסט עברי מורכב עם ניקוד: שָׁלוֹם עֲלֵיכֶם. זהו מבחן לשילוב של אותיות, ניקוד וסימנים. בדיקת BiDi: שלום עולם — Hello World.' },
+
+                    { type: 'heading', text: 'Thai cluster shaping', level: 2 },
+                    { type: 'paragraph', text: 'การทดสอบภาษาไทย: สวัสดีครับ ขอบคุณมากครับ การประมวลผลข้อความที่มีพยัญชนะและสระและวรรณยุกต์ซ้อนกันต้องวางตำแหน่งให้ถูกต้อง.' },
+
+                    { type: 'heading', text: 'Heavy mixed BiDi', level: 2 },
+                    { type: 'paragraph', text: 'مثال BiDi قوي: السلام عليكم 654321 — שלום עולם — สวัสดี + Hello from Thailand 789 (mix Arabic + Hebrew + Thai + English + numbers).' },
+                    { type: 'paragraph', text: 'هذا النص العربي الطويل جدًا لاختبار خوارزمية BiDi و line-breaking والـ shaping في الوقت نفسه. يجب أن يتم عرضه من اليمين إلى اليسار بشكل صحيح مع الحفاظ على السياق والروابط بين الحروف حتى في الجمل الطويلة والمعقدة التي تحتوي على أرقام وكلمات أجنبية.' },
+
+                    { type: 'heading', text: 'Bullet stress', level: 2 },
+                    { type: 'list', items: [
+                        'اختبار shaping عربي: الله أكبر',
+                        'בדיקת עברית: ברכות',
+                        'การทดสอบภาษาไทย: สวัสดีครับ',
+                        'مثال مختلط: مرحبا — שלום — สวัสดี',
+                    ], style: 'bullet' },
+                ],
+                footerText: 'pdfnative — extreme BiDi visual regression baseline',
+                fontEntries,
+            };
+            ctx.writeSafe(resolve(ctx.outputDir, 'extreme', 'extreme-bidi.pdf'), 'extreme/extreme-bidi.pdf', buildDocumentPDFBytes(params));
+        }
+    }
+
+    // ── 2. Tamil ultra-extreme: deep conjuncts + split vowels + BiDi mix
+    {
+        const fontEntries = await loadSelectedFontEntries(['ta', 'ar']);
+        if (fontEntries.length === 2) {
+            const params: DocumentParams = {
+                title: 'Extreme Tamil — Conjuncts, Split Vowels, BiDi Mix',
+                blocks: [
+                    { type: 'heading', text: 'Tamil ultra-extreme — shaping & positioning', level: 1 },
+                    { type: 'paragraph', text: 'எழுத்துக்களின் stacking சோதனை: க கா கி கீ கு கூ கெ கே கை கொ கோ கௌ க்ஷ க்ஷி க்ஷீ க்ஷு க்ஷூ க்ஷெ க்ஷே க்ஷை க்ஷொ க்ஷோ க்ஷௌ.' },
+                    { type: 'paragraph', text: 'இது ஒரு மிக நீண்ட தமிழ் வரிக்கையம். இதில் எழுத்துக்களின் இணைப்பு, உயிர்மெய் எழுத்துக்கள், ஒற்றெழுத்துக்கள், சிந்த, வில்லினம் மெல்லினம் இடையினம் ஆகியவற்றின் சரியான விடவமைப்பை சேரிதிக்கிறோம். தமிழ் மொழியின் எழுத்து அமைப்பு மிகவும் சிக்கலானது.' },
+                    { type: 'paragraph', text: 'BiDi extreme mix: வணக்கம் ௧௨௩௪௫ — 123456 — السلام عليكم — Hello from தமிழ்நாடு (Tamil + Arabic + English + numbers).' },
+                    { type: 'list', items: [
+                        'லக்ஷ்மீ சோதனை: தமிழ்நாடு செய்ய்யவென்ன',
+                        'உயிர்மெய் stacking: கி கீ கு கூ கெ கே',
+                        'BiDi mix: வணக்கம் — مرحبا — Hello',
+                        'எண்கள்: ௧௨௩௪௫௬௭௮௯௦',
+                    ], style: 'bullet' },
+                    { type: 'paragraph', text: 'முடிவு: pdfnative நூலகம் தமிழ் எழுத்துக்களை pure TypeScript இல் சிறப்பாக கையாளுகிறது என்று நம்புகிறோம். இது ஒரு சிறந்த முயற்சி. தமிழ் மொழியின் சிக்கலான எழுத்து விடவமைப்பை சரியாக ரெண்டர் செய்யும் திறன் மிக முக்கியம்.' },
+                ],
+                footerText: 'pdfnative — extreme Tamil visual regression baseline',
+                fontEntries,
+            };
+            ctx.writeSafe(resolve(ctx.outputDir, 'extreme', 'extreme-tamil.pdf'), 'extreme/extreme-tamil.pdf', buildDocumentPDFBytes(params));
+        }
+    }
+
+    // ── 3. Bengali + Devanagari ultra-extreme: reph + multi-halant ─
+    {
+        const fontEntries = await loadSelectedFontEntries(['bn', 'hi', 'ar']);
+        if (fontEntries.length === 3) {
+            const params: DocumentParams = {
+                title: 'Extreme Bengali + Devanagari — Reph, Conjuncts, Matras',
+                blocks: [
+                    { type: 'heading', text: 'Bengali & Devanagari extreme — shaping & positioning', level: 1 },
+                    { type: 'paragraph', text: 'বাংলা stacking ও conjuncts পরীক্ষা: ক কা কি কী কু কূ কে কৈ কো কৌ ক্ত ক্ক ক্ষ ক্ষ্ম ক্ষ্ণ ক্ল ক্ব ক্য ক্র ক্ল ক্শ ক্ষ্ণ ক্ষ্ম ক্রু লক্ষ্মী.' },
+                    { type: 'paragraph', text: 'देवनागरी stacking और conjuncts परीक्षा: क का कि की कु कू के कै को कौ क्त क्क क्ष क्ष्म क्ष्ण क्ल क्व क्म क्य क्र क्ल क्ष्ण क्र क्लु क्ष्मी.' },
+                    { type: 'paragraph', text: 'এটি একটি অত্যন্ত দীর্ঘ বাংলা বাক্য যা লাইন ব্রেকিং, শেপিং এবং যুক্তাক্ষরের সঠিক অবস্থান পরীক্ষা করে। বাংলা লিপির জটিলতা অনেক বেশি, বিশেষ করে যুক্তাক্ষর এবং স্বরচিহ্নের সঠিক স্থাপনা।' },
+                    { type: 'paragraph', text: 'यह एक अत्यंत लंबा देवनागरी वाक्य है जो लाइन ब्रेकिंग, शेपिंग और संयुक्ताक्षर की सही स्थिति की परीक्षा करता है। देवनागरी लिपि की जटिलता बहुत अधिक है, विशेष रूप से संयुक्ताक्षर और स्वर चिह्नों की सही स्थापना में।' },
+                    { type: 'paragraph', text: 'BiDi extreme mix: বাংলা ১২৩৪৫ — हिंदी ६७८९० — السلام عليكم — Hello from বাংলাদেশ और भारत (Bengali + Devanagari + Arabic + English).' },
+                    { type: 'list', items: [
+                        'বাংলা যুক্তাক্ষর: ক্ষ ক্ষ্ম ক্ষ্ণ ক্র ক্ল',
+                        'देवनागरी conjuncts: क्ष क्ष्म क्ष्ण क्र क्ल',
+                        'BiDi mix: বাংলা — हिंदी — مرحبا — Hello',
+                        'সংখ্যা: ১২৩৪৫৬৭৮৯০ — १२३४५६७८९०',
+                    ], style: 'bullet' },
+                    { type: 'paragraph', text: 'সারাংশ: pdfnative লাইব্রেরি বাংলা ও দেবনাগরী লিপির shaping pure TypeScript-এ ভালোভাবে পরিচালনা করছে বলে মনে হয়। এটি একটি প্রশংসনীয় প্রচেষ্টা।' },
+                ],
+                footerText: 'pdfnative — extreme Bengali + Devanagari visual regression baseline',
+                fontEntries,
+            };
+            ctx.writeSafe(resolve(ctx.outputDir, 'extreme', 'extreme-bengali-devanagari.pdf'), 'extreme/extreme-bengali-devanagari.pdf', buildDocumentPDFBytes(params));
+        }
+    }
+
+    // ── 4. Arabic harakat regression — isolated diacritic stress ──
+    {
+        const fontEntries = await loadSelectedFontEntries(['ar']);
+        if (fontEntries.length === 1) {
+            const params: DocumentParams = {
+                title: 'Extreme Arabic — Harakat & Tashkeel Anchoring',
+                blocks: [
+                    { type: 'heading', text: 'Arabic harakat — isolated and contextual', level: 1 },
+                    { type: 'paragraph', text: 'النص محرَّك بالكامل: بِسْمِ ٱللَّٰهِ ٱلرَّحْمَٰنِ ٱلرَّحِيمِ — ٱلْحَمْدُ لِلَّٰهِ رَبِّ ٱلْعَٰلَمِينَ.' },
+                    { type: 'paragraph', text: 'علامات التشكيل المعزولة على التطويل: ـَ ـِ ـُ ـً ـٍ ـٌ ـّ ـْ.' },
+                    { type: 'paragraph', text: 'مع التشكيل المركَّب: مَدَرَسَةٌ — كِتَابٌ — قَلَمٌ — طَالِبٌ — مُعَلِّمَةٌ.' },
+                    { type: 'paragraph', text: 'النص الكامل المركَّب: ٱلسَّلَامُ عَلَيْكُمْ وَرَحْمَةُ ٱللَّٰهِ وَبَرَكَاتُهُ.' },
+                    { type: 'list', items: [
+                        'فتحة: ـَ',
+                        'كسرة: ـِ',
+                        'ضمة: ـُ',
+                        'تنوين الفتح: ـً',
+                        'تنوين الكسر: ـٍ',
+                        'تنوين الضم: ـٌ',
+                        'شدة: ـّ',
+                        'سكون: ـْ',
+                    ], style: 'bullet' },
+                ],
+                footerText: 'pdfnative — extreme Arabic harakat visual regression baseline',
+                fontEntries,
+            };
+            ctx.writeSafe(resolve(ctx.outputDir, 'extreme', 'extreme-arabic-harakat.pdf'), 'extreme/extreme-arabic-harakat.pdf', buildDocumentPDFBytes(params));
+        }
+    }
+}

--- a/src/core/pdf-renderers.ts
+++ b/src/core/pdf-renderers.ts
@@ -204,10 +204,46 @@ function tokenizeForWrap(text: string): string[] {
 }
 
 /**
+ * Hard-break a single overlong segment at character boundaries so no
+ * single piece exceeds maxWidth. Used as a last-resort fallback when
+ * a single token (e.g. a long URL, NBSP-joined title, or non-breaking
+ * compound) would otherwise overflow the content width.
+ *
+ * Iterates by Unicode code points (not UTF-16 units) to keep surrogate
+ * pairs and combining sequences intact at the slice boundary.
+ */
+function hardBreakSegment(
+    seg: string,
+    maxWidth: number,
+    fontSize: number,
+    enc: EncodingContext,
+): string[] {
+    const pieces: string[] = [];
+    let buf = '';
+    for (const ch of seg) {
+        const candidate = buf + ch;
+        const w = measureText(candidate, fontSize, enc);
+        if (w <= maxWidth || buf === '') {
+            buf = candidate;
+        } else {
+            pieces.push(buf);
+            buf = ch;
+        }
+    }
+    if (buf) pieces.push(buf);
+    return pieces.length > 0 ? pieces : [seg];
+}
+
+/**
  * Wrap text into lines that fit within maxWidth.
  * Greedy line-filling algorithm with CJK character-level breaking.
  * Latin text breaks at word boundaries (spaces).
  * CJK characters break individually (no spaces needed).
+ *
+ * If a single segment exceeds maxWidth (e.g. a long word, URL, or
+ * non-breaking-space-joined compound), it is hard-broken at character
+ * boundaries to prevent overflow past the right margin. This is critical
+ * for headings and titles that may contain long compounds without spaces.
  */
 export function wrapText(
     text: string,
@@ -227,12 +263,31 @@ export function wrapText(
     for (const seg of segments) {
         const candidate = currentLine + seg;
         const w = measureText(candidate, fontSize, enc);
-        if (w <= maxWidth || currentLine === '') {
+        if (w <= maxWidth) {
             currentLine = candidate;
-        } else {
-            lines.push(currentLine.trimEnd());
-            currentLine = seg.trimStart();
+            continue;
         }
+
+        // Flush whatever fit so far on the current line.
+        if (currentLine !== '') {
+            lines.push(currentLine.trimEnd());
+            currentLine = '';
+        }
+
+        // Try to fit the segment by itself on a fresh line.
+        const segTrim = seg.trimStart();
+        const segW = measureText(segTrim, fontSize, enc);
+        if (segW <= maxWidth) {
+            currentLine = segTrim;
+            continue;
+        }
+
+        // Segment alone still overflows — hard-break at character boundaries.
+        const pieces = hardBreakSegment(segTrim, maxWidth, fontSize, enc);
+        for (let pi = 0; pi < pieces.length - 1; pi++) {
+            lines.push(pieces[pi].trimEnd());
+        }
+        currentLine = pieces[pieces.length - 1];
     }
     if (currentLine) lines.push(currentLine.trimEnd());
 

--- a/tests/core/pdf-document.test.ts
+++ b/tests/core/pdf-document.test.ts
@@ -57,9 +57,24 @@ describe('wrapText', () => {
         expect(lines).toEqual(['Hello world']);
     });
 
-    it('should handle single word that exceeds width', () => {
+    it('should hard-break single word that exceeds width at character boundaries', () => {
+        // v1.0.3+: overlong tokens are hard-broken instead of overflowing the page.
         const lines = wrapText('Supercalifragilisticexpialidocious', 10, 10, enc);
-        expect(lines).toEqual(['Supercalifragilisticexpialidocious']);
+        expect(lines.length).toBeGreaterThan(1);
+        // Each piece must individually fit (or be a single character — last-resort).
+        for (const line of lines) {
+            expect(line.length).toBeGreaterThan(0);
+        }
+        // Round-tripping the pieces reconstructs the original.
+        expect(lines.join('')).toBe('Supercalifragilisticexpialidocious');
+    });
+
+    it('should hard-break long titles with non-breaking compounds (heading overflow regression)', () => {
+        // Regression: long heading like "Test Bengali + Devanagari ULTRA EXTREME — Shaping & Positioning — pdfnative"
+        // would overflow the right margin in v1.0.2. v1.0.3 wraps to multiple lines.
+        const longTitle = 'Test Bengali + Devanagari ULTRA EXTREME — Shaping & Positioning — pdfnative';
+        const lines = wrapText(longTitle, 200, 18, enc);
+        expect(lines.length).toBeGreaterThan(1);
     });
 
     it('should split on spaces', () => {

--- a/tests/integration/extreme-shaping.test.ts
+++ b/tests/integration/extreme-shaping.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Integration tests for extreme-script shaping.
+ *
+ * Confirms that the document builder produces a valid PDF when fed the
+ * same extreme inputs used by `scripts/generators/extreme-shaping.ts`:
+ * deep BiDi mixing across 3+ scripts, complex Indic conjuncts with reph
+ * + multi-halant chains, isolated Arabic harakat, and Thai mark stacking
+ * on tall consonants.
+ *
+ * These tests guard against regressions in the shaping pipeline. They
+ * use mock font data (no GSUB/GPOS lookups), so they validate the
+ * pipeline integrity rather than visual correctness — the latter is
+ * verified by visually reviewing the generated PDFs in `test-output/extreme/`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildDocumentPDFBytes } from '../../src/core/pdf-document.js';
+import type { DocumentParams } from '../../src/types/pdf-document-types.js';
+import type { FontData, FontEntry } from '../../src/types/pdf-types.js';
+
+/** Minimal mock FontData covering arbitrary Unicode codepoints. */
+function makeMockFontData(name: string): FontData {
+    // Generic cmap that maps every codepoint to itself + 1 (avoid GID 0).
+    const cmap: Record<number, number> = {};
+    const widths: Record<number, number> = {};
+    return {
+        metrics: { unitsPerEm: 1000, numGlyphs: 0xFFFF, defaultWidth: 500, ascent: 800, descent: -200, bbox: [0, -200, 600, 800], capHeight: 700, stemV: 50 },
+        fontName: name,
+        cmap: new Proxy(cmap, {
+            get(_target, prop) {
+                if (typeof prop === 'string') {
+                    const cp = Number(prop);
+                    if (!Number.isNaN(cp) && cp > 0) return cp;
+                }
+                return 0;
+            },
+            has() { return true; },
+        }),
+        defaultWidth: 500,
+        widths: new Proxy(widths, { get() { return 500; }, has() { return true; } }),
+        pdfWidthArray: '',
+        ttfBase64: 'AAAAAAAAAA==',
+        gsub: {},
+        markAnchors: null,
+        mark2mark: null,
+    };
+}
+
+function makeFontEntries(): FontEntry[] {
+    return [
+        { fontData: makeMockFontData('MockArabic'), fontRef: '/F3', lang: 'ar' },
+        { fontData: makeMockFontData('MockHebrew'), fontRef: '/F4', lang: 'he' },
+        { fontData: makeMockFontData('MockThai'), fontRef: '/F5', lang: 'th' },
+        { fontData: makeMockFontData('MockTamil'), fontRef: '/F6', lang: 'ta' },
+        { fontData: makeMockFontData('MockBengali'), fontRef: '/F7', lang: 'bn' },
+        { fontData: makeMockFontData('MockHindi'), fontRef: '/F8', lang: 'hi' },
+    ];
+}
+
+function expectValidPdfBytes(bytes: Uint8Array): void {
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    expect(bytes.length).toBeGreaterThan(100);
+    const header = new TextDecoder('latin1').decode(bytes.slice(0, 8));
+    expect(header.startsWith('%PDF-')).toBe(true);
+    const tail = new TextDecoder('latin1').decode(bytes.slice(-32));
+    expect(tail).toContain('%%EOF');
+}
+
+describe('Extreme shaping — integration', () => {
+    const fontEntries = makeFontEntries();
+
+    it('builds extreme BiDi mix (Arabic + Hebrew + Thai + Latin + digits)', () => {
+        const params: DocumentParams = {
+            title: 'Extreme BiDi',
+            blocks: [
+                { type: 'heading', text: 'Extreme BiDi — Arabic + Hebrew + Thai + Latin + Numerals', level: 1 },
+                { type: 'paragraph', text: 'مثال BiDi قوي: السلام عليكم 654321 — שלום עולם — สวัสดี + Hello from Thailand 789.' },
+                { type: 'list', items: [
+                    'اختبار shaping عربي: الله أكبر',
+                    'בדיקת עברית: ברכות',
+                    'การทดสอบภาษาไทย: สวัสดีครับ',
+                    'مثال مختلط: مرحبا — שלום — สวัสดี',
+                ], style: 'bullet' },
+            ],
+            fontEntries,
+        };
+        expectValidPdfBytes(buildDocumentPDFBytes(params));
+    });
+
+    it('builds extreme Tamil with conjuncts, split vowels, BiDi mix', () => {
+        const params: DocumentParams = {
+            title: 'Extreme Tamil',
+            blocks: [
+                { type: 'heading', text: 'Tamil ultra-extreme', level: 1 },
+                { type: 'paragraph', text: 'எழுத்துக்களின் stacking: க கா கி கீ கு கூ கெ கே கை கொ கோ கௌ க்ஷ க்ஷி க்ஷீ க்ஷு க்ஷூ.' },
+                { type: 'paragraph', text: 'BiDi mix: வணக்கம் ௧௨௩௪௫ — 123456 — السلام عليكم — Hello from தமிழ்நாடு.' },
+            ],
+            fontEntries,
+        };
+        expectValidPdfBytes(buildDocumentPDFBytes(params));
+    });
+
+    it('builds extreme Bengali + Devanagari with reph + multi-halant chains', () => {
+        const params: DocumentParams = {
+            title: 'Extreme Bengali + Devanagari',
+            blocks: [
+                { type: 'heading', text: 'Bengali & Devanagari extreme', level: 1 },
+                { type: 'paragraph', text: 'বাংলা: ক ক্ত ক্ক ক্ষ ক্ষ্ম ক্ষ্ণ ক্ল ক্ব ক্য ক্র লক্ষ্মী.' },
+                { type: 'paragraph', text: 'देवनागरी: क क्त क्क क्ष क्ष्म क्ष्ण क्ल क्व क्म क्य क्र क्लु क्ष्मी.' },
+                { type: 'paragraph', text: 'BiDi mix: বাংলা ১২৩৪৫ — हिंदी ६७८९० — السلام عليكم — Hello.' },
+            ],
+            fontEntries,
+        };
+        expectValidPdfBytes(buildDocumentPDFBytes(params));
+    });
+
+    it('builds extreme Arabic with isolated harakat + tatweel', () => {
+        const params: DocumentParams = {
+            title: 'Extreme Arabic harakat',
+            blocks: [
+                { type: 'heading', text: 'Arabic harakat — isolated and contextual', level: 1 },
+                { type: 'paragraph', text: 'بِسْمِ ٱللَّٰهِ ٱلرَّحْمَٰنِ ٱلرَّحِيمِ' },
+                { type: 'paragraph', text: 'علامات التشكيل المعزولة على التطويل: ـَ ـِ ـُ ـً ـٍ ـٌ ـّ ـْ.' },
+                { type: 'list', items: [
+                    'فتحة: ـَ',
+                    'كسرة: ـِ',
+                    'ضمة: ـُ',
+                    'شدة: ـّ',
+                    'سكون: ـْ',
+                ], style: 'bullet' },
+            ],
+            fontEntries,
+        };
+        expectValidPdfBytes(buildDocumentPDFBytes(params));
+    });
+
+    it('handles overlong heading with em-dashes (regression: heading hard-break)', () => {
+        const params: DocumentParams = {
+            title: 'Long heading test',
+            blocks: [
+                { type: 'heading', text: 'Test Bengali + Devanagari ULTRA EXTREME — Shaping & Positioning — pdfnative', level: 1 },
+                { type: 'paragraph', text: 'Body.' },
+            ],
+            fontEntries,
+        };
+        expectValidPdfBytes(buildDocumentPDFBytes(params));
+    });
+});


### PR DESCRIPTION
…unds

## Description

Patch release v1.0.3 — no public API change, fully backward-compatible with v1.0.2.

**Fix:** `wrapText()` now hard-breaks single overlong tokens at character boundaries when no whitespace breakpoint exists. Long compound headings such as `"Test Bengali + Devanagari ULTRA EXTREME — Shaping & Positioning — pdfnative"` previously overflowed the right margin. Code points are honored so surrogate pairs and combining sequences remain intact at slice boundaries. (`src/core/pdf-renderers.ts`)

**Extreme-script baselines:** new `extreme-shaping.ts` generator producing four visual-regression PDFs under `test-output/extreme/` — BiDi (Arabic + Hebrew + Thai + Latin + digits), Tamil ultra-conjuncts, Bengali + Devanagari reph + multi-halant chains, isolated Arabic harakat. Five integration tests added (`tests/integration/extreme-shaping.test.ts`).

**Playgrounds:** two new interactive pages on `pdfnative.dev` — `extreme-scripts.html` (live shaping stress-tester with editable presets) and `medical-800.html` (Web Worker showcase generating an 800-page synthetic clinical report via `buildDocumentPDFStream`, seeded RNG, no real PHI).

**Docs:** static HTML guide pages (`quickstart`, `architecture`, `faq`, `troubleshooting`, `accessibility`), guides index, `quickstart.md` and `accessibility.md`, FAQ rewrite, README Documentation section, Indic samples table rows, BibTeX citation block. Landing page: project-status badge row, rebuilt 10-example "Try It Live" gallery, Guides + Playgrounds navbar entries.

Deeper shaping issues exposed by the new baselines (Arabic isolated harakat GPOS anchoring, Thai tall-consonant mark stacking, multi-stage Indic ligature chains, 3+ RTL-script BiDi run ordering) are documented as known limitations and tracked for v1.1.0 — they require GPOS table re-extraction and exceed SemVer-patch scope.

## Related Issues

Closes #24
Relates to #22 (landing page v2 — docs/guides shipped from Unreleased queue)

## Checklist

- [x] Tests pass (`npm run test`) — 1 606 / 1 606
- [x] Type check passes (`npm run typecheck:all`) — clean
- [x] Lint passes (`npm run lint`) — 0 errors
- [x] New code has tests (5 integration + regression tests added, coverage thresholds maintained)
- [x] CHANGELOG.md updated
- [x] No breaking changes (`wrapText` behavioral fix only — overflow was always visually broken)