### PR TITLE
docs: add pdfnative-mcp integration across README, landing page, guid…

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![npm provenance](https://img.shields.io/badge/provenance-signed-blueviolet)](https://docs.npmjs.com/generating-provenance-statements)
 [![website](https://img.shields.io/badge/pdfnative.dev-0066FF?logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0id2hpdGUiPjxyZWN0IHg9IjMiIHk9IjIiIHdpZHRoPSIxNCIgaGVpZ2h0PSIxOCIgcng9IjIiIGZpbGw9Im5vbmUiIHN0cm9rZT0id2hpdGUiIHN0cm9rZS13aWR0aD0iMS41Ii8+PHBhdGggZD0iTTcgN2g2TTcgMTFoOE03IDE1aDQiIHN0cm9rZT0id2hpdGUiIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWNhcD0icm91bmQiLz48L3N2Zz4=)](https://pdfnative.dev)
+[![pdfnative-mcp](https://img.shields.io/npm/v/pdfnative-mcp?label=pdfnative-mcp&color=6366f1)](https://www.npmjs.com/package/pdfnative-mcp)
 
 Pure native PDF generation library — zero vendor dependencies. ISO 32000-1 (PDF 1.7) compliant.
 
@@ -44,6 +45,7 @@ Pure native PDF generation library — zero vendor dependencies. ISO 32000-1 (PD
 - **NPM provenance** — signed builds via GitHub Actions OIDC
 - **On-device generation** — runs in Node, browsers, Workers, Deno, Bun. No SaaS round-trip; documents never leave the calling process unless your application explicitly sends them
 - **No telemetry, no network calls** — verifiable in source. The library never opens a socket, fetches remote fonts, or phones home
+- **AI client integration** — use pdfnative from Claude Desktop, Cursor, Continue, and Zed via [`pdfnative-mcp`](https://github.com/Nizoka/pdfnative-mcp)
 
 ## Installation
 
@@ -803,6 +805,45 @@ const pdf = buildPDFBytes(params, { compress: true });
 | `HEADER_H` | Header zone height (15pt) |
 | `PAGE_SIZES` | Preset page dimensions (A4, Letter, Legal, A3, Tabloid) |
 | `resolveTemplate(tpl, page, pages, title, date)` | Resolve header/footer template placeholders |
+
+## Ecosystem
+
+[`pdfnative-mcp`](https://github.com/Nizoka/pdfnative-mcp) is a **Model Context Protocol server** that bridges pdfnative to any MCP-compatible AI client. Once configured, your AI assistant can generate PDFs, embed barcodes, create forms, sign documents, and render international text — all without writing code.
+
+```bash
+npx -y pdfnative-mcp
+```
+
+### Available tools
+
+| Tool | Purpose |
+|------|---------|
+| `generate_basic_pdf` | Multi-page documents from structured blocks (headings, paragraphs, lists) |
+| `add_table` | Tabular reports from column headers and data rows |
+| `add_barcode` | QR Code, Code 128, EAN-13, Data Matrix, PDF417 |
+| `add_international_text` | 16 non-Latin scripts with BiDi & OpenType shaping |
+| `add_form` | Interactive AcroForm PDFs (text, checkbox, radio, dropdown) |
+| `embed_image` | Embed a JPEG or PNG image (base64) |
+| `prepare_signature_placeholder` | PDF with a `/Sig` field ready to be signed |
+| `sign_pdf` | CMS/PKCS#7 digital signatures (RSA-SHA256 / ECDSA-SHA256) |
+
+### Claude Desktop configuration
+
+```json
+{
+  "mcpServers": {
+    "pdfnative": {
+      "command": "npx",
+      "args": ["-y", "pdfnative-mcp"],
+      "env": {
+        "PDFNATIVE_MPC_OUTPUT_DIR": "/Users/you/Documents/mcp-pdfs"
+      }
+    }
+  }
+}
+```
+
+See the [MCP Integration Guide](https://pdfnative.dev/guides/mcp.html) and the [pdfnative-mcp repository](https://github.com/Nizoka/pdfnative-mcp) for configuration on Cursor, Continue, Zed, and more.
 
 ## Architecture
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,6 +36,7 @@ This document outlines the planned development direction for pdfnative. Prioriti
 - [x] **Streaming output** — AsyncGenerator-based progressive PDF emission with configurable chunk size (64 KB default), validation for TOC/template incompatibility, concatChunks utility
 - [x] **PDF parser & modifier** — full PDF reader (tokenizer, object parser, xref table/stream, page tree, FlateDecode inflate) + incremental modification (non-destructive save with /Prev chain)
 - [x] **npm metadata enrichment** — description enumerates 16 scripts + headline features (BiDi, PDF/A, encryption, signatures, AcroForm, barcodes, SVG); keywords expanded to 27 entries for npm search discoverability (v1.0.2)
+- [x] **pdfnative-mcp** — Model Context Protocol server bridging pdfnative to AI clients (Claude Desktop, Cursor, Continue, Zed): 8 production tools (`generate_basic_pdf`, `add_table`, `add_barcode`, `add_international_text`, `add_form`, `embed_image`, `prepare_signature_placeholder`, `sign_pdf`), stdio/HTTP transport, sandboxed file output. See [pdfnative-mcp on GitHub](https://github.com/Nizoka/pdfnative-mcp)
 
 ## In Progress
 

--- a/docs/assets/architecture.svg
+++ b/docs/assets/architecture.svg
@@ -1,75 +1,109 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 360" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 540" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif">
+  <title>pdfnative — Module Architecture</title>
+  <desc>Dependency diagram showing pdfnative's internal modules (core, fonts, shaping, worker, crypto, parser, types) and the external pdfnative-mcp ecosystem consumer.</desc>
+
   <defs>
-    <marker id="arrow" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="8" markerHeight="6" orient="auto-start-reverse">
+    <marker id="arrow" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="7" markerHeight="5" orient="auto-start-reverse">
       <polygon points="0 0, 10 3.5, 0 7" fill="#94A3B8"/>
     </marker>
-    <filter id="shadow">
-      <feDropShadow dx="0" dy="2" stdDeviation="3" flood-opacity="0.1"/>
+    <marker id="arrow-mcp" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="7" markerHeight="5" orient="auto-start-reverse">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#6366F1"/>
+    </marker>
+    <marker id="arrow-green" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="7" markerHeight="5" orient="auto-start-reverse">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#10B981"/>
+    </marker>
+    <marker id="arrow-orange" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="7" markerHeight="5" orient="auto-start-reverse">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#F97316"/>
+    </marker>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="130%">
+      <feDropShadow dx="0" dy="2" stdDeviation="3" flood-color="#0F172A" flood-opacity="0.10"/>
     </filter>
   </defs>
 
-  <!-- Background -->
-  <rect width="800" height="360" fill="none"/>
+  <!-- ── Diagram title ──────────────────────────────────────────── -->
+  <text x="480" y="28" text-anchor="middle" font-size="15" font-weight="700" fill="#1E293B" letter-spacing="0.3">pdfnative — Module Architecture</text>
+
+  <!-- ════════════════════════════════════════════════════════════ -->
+  <!-- ECOSYSTEM ZONE (external consumers)                         -->
+  <!-- ════════════════════════════════════════════════════════════ -->
+  <rect x="30" y="44" width="900" height="110" rx="12" fill="none" stroke="#A5B4FC" stroke-width="1.5" stroke-dasharray="8,4"/>
+  <text x="48" y="64" font-size="11" font-weight="600" fill="#6366F1" letter-spacing="0.5">ECOSYSTEM</text>
+
+  <!-- pdfnative-mcp box -->
+  <rect x="350" y="72" width="260" height="68" rx="10" fill="#EEF2FF" stroke="#6366F1" stroke-width="2" filter="url(#shadow)"/>
+  <text x="480" y="100" text-anchor="middle" font-size="15" font-weight="700" fill="#4338CA">pdfnative-mcp</text>
+  <text x="480" y="118" text-anchor="middle" font-size="11" fill="#6366F1">MCP Server · 8 tools</text>
+  <text x="480" y="132" text-anchor="middle" font-size="10" fill="#818CF8">Claude · Cursor · Continue · Zed</text>
+
+  <!-- ════════════════════════════════════════════════════════════ -->
+  <!-- PDFNATIVE LIBRARY ZONE                                      -->
+  <!-- ════════════════════════════════════════════════════════════ -->
+  <rect x="30" y="168" width="900" height="340" rx="12" fill="none" stroke="#CBD5E1" stroke-width="1" stroke-dasharray="0"/>
+  <text x="48" y="188" font-size="11" font-weight="600" fill="#64748B" letter-spacing="0.5">PDFNATIVE LIBRARY</text>
 
   <!-- types box -->
-  <rect x="20" y="140" width="100" height="60" rx="10" fill="#F1F5F9" stroke="#CBD5E1" stroke-width="1.5" filter="url(#shadow)"/>
-  <text x="70" y="175" text-anchor="middle" font-size="14" font-weight="600" fill="#475569">types</text>
+  <rect x="56" y="230" width="110" height="62" rx="10" fill="#F8FAFC" stroke="#CBD5E1" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="111" y="267" text-anchor="middle" font-size="14" font-weight="600" fill="#475569">types</text>
 
   <!-- core box -->
-  <rect x="180" y="100" width="160" height="140" rx="10" fill="#DBEAFE" stroke="#3B82F6" stroke-width="2" filter="url(#shadow)"/>
-  <text x="260" y="137" text-anchor="middle" font-size="16" font-weight="700" fill="#1D4ED8">core</text>
-  <text x="260" y="158" text-anchor="middle" font-size="10" fill="#3B82F6">pdf-builder</text>
-  <text x="260" y="172" text-anchor="middle" font-size="10" fill="#3B82F6">pdf-document</text>
-  <text x="260" y="186" text-anchor="middle" font-size="10" fill="#3B82F6">pdf-encrypt</text>
-  <text x="260" y="200" text-anchor="middle" font-size="10" fill="#3B82F6">pdf-tags</text>
-  <text x="260" y="214" text-anchor="middle" font-size="10" fill="#3B82F6">+ 12 modules</text>
+  <rect x="230" y="196" width="175" height="148" rx="10" fill="#DBEAFE" stroke="#3B82F6" stroke-width="2" filter="url(#shadow)"/>
+  <text x="317" y="231" text-anchor="middle" font-size="16" font-weight="700" fill="#1D4ED8">core</text>
+  <text x="317" y="252" text-anchor="middle" font-size="11" fill="#3B82F6">pdf-builder</text>
+  <text x="317" y="268" text-anchor="middle" font-size="11" fill="#3B82F6">pdf-document</text>
+  <text x="317" y="284" text-anchor="middle" font-size="11" fill="#3B82F6">pdf-encrypt</text>
+  <text x="317" y="300" text-anchor="middle" font-size="11" fill="#3B82F6">pdf-tags</text>
+  <text x="317" y="316" text-anchor="middle" font-size="11" fill="#3B82F6">+ 12 modules</text>
 
   <!-- fonts box -->
-  <rect x="400" y="100" width="120" height="60" rx="10" fill="#F3E8FF" stroke="#8B5CF6" stroke-width="1.5" filter="url(#shadow)"/>
-  <text x="460" y="135" text-anchor="middle" font-size="14" font-weight="600" fill="#6D28D9">fonts</text>
+  <rect x="468" y="196" width="130" height="62" rx="10" fill="#F3E8FF" stroke="#8B5CF6" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="533" y="233" text-anchor="middle" font-size="14" font-weight="600" fill="#6D28D9">fonts</text>
 
   <!-- shaping box -->
-  <rect x="400" y="200" width="120" height="60" rx="10" fill="#CCFBF1" stroke="#14B8A6" stroke-width="1.5" filter="url(#shadow)"/>
-  <text x="460" y="228" text-anchor="middle" font-size="14" font-weight="600" fill="#0D9488">shaping</text>
-  <text x="460" y="245" text-anchor="middle" font-size="9" fill="#14B8A6">BiDi · Thai · Arabic</text>
+  <rect x="468" y="298" width="130" height="64" rx="10" fill="#CCFBF1" stroke="#14B8A6" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="533" y="326" text-anchor="middle" font-size="14" font-weight="600" fill="#0D9488">shaping</text>
+  <text x="533" y="345" text-anchor="middle" font-size="10" fill="#14B8A6">BiDi · Thai · Arabic</text>
 
   <!-- worker box -->
-  <rect x="580" y="140" width="110" height="60" rx="10" fill="#FEF3C7" stroke="#F59E0B" stroke-width="1.5" filter="url(#shadow)"/>
-  <text x="635" y="175" text-anchor="middle" font-size="14" font-weight="600" fill="#D97706">worker</text>
+  <rect x="664" y="236" width="120" height="62" rx="10" fill="#FEF3C7" stroke="#F59E0B" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="724" y="273" text-anchor="middle" font-size="14" font-weight="600" fill="#D97706">worker</text>
 
   <!-- crypto box -->
-  <rect x="180" y="290" width="120" height="55" rx="10" fill="#D1FAE5" stroke="#10B981" stroke-width="1.5" filter="url(#shadow)"/>
-  <text x="240" y="318" text-anchor="middle" font-size="14" font-weight="600" fill="#059669">crypto</text>
-  <text x="240" y="335" text-anchor="middle" font-size="9" fill="#10B981">AES · RSA · ECDSA</text>
+  <rect x="230" y="410" width="130" height="62" rx="10" fill="#D1FAE5" stroke="#10B981" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="295" y="437" text-anchor="middle" font-size="14" font-weight="600" fill="#059669">crypto</text>
+  <text x="295" y="455" text-anchor="middle" font-size="10" fill="#10B981">AES · RSA · ECDSA</text>
 
   <!-- parser box -->
-  <rect x="360" y="290" width="120" height="55" rx="10" fill="#FFEDD5" stroke="#F97316" stroke-width="1.5" filter="url(#shadow)"/>
-  <text x="420" y="318" text-anchor="middle" font-size="14" font-weight="600" fill="#EA580C">parser</text>
-  <text x="420" y="335" text-anchor="middle" font-size="9" fill="#F97316">read · modify · xref</text>
+  <rect x="430" y="410" width="130" height="62" rx="10" fill="#FFEDD5" stroke="#F97316" stroke-width="1.5" filter="url(#shadow)"/>
+  <text x="495" y="437" text-anchor="middle" font-size="14" font-weight="600" fill="#EA580C">parser</text>
+  <text x="495" y="455" text-anchor="middle" font-size="10" fill="#F97316">read · modify · xref</text>
 
-  <!-- Arrows: types → core -->
-  <line x1="120" y1="170" x2="175" y2="170" stroke="#94A3B8" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <!-- ─── Arrows ──────────────────────────────────────────────── -->
 
-  <!-- Arrows: core ← fonts -->
-  <line x1="396" y1="130" x2="345" y2="150" stroke="#94A3B8" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <!-- pdfnative-mcp → core (dashed, external consumer) -->
+  <line x1="480" y1="142" x2="370" y2="194" stroke="#6366F1" stroke-width="1.8" stroke-dasharray="7,4" marker-end="url(#arrow-mcp)"/>
+  <text x="385" y="168" font-size="10" fill="#6366F1">npm install pdfnative</text>
 
-  <!-- Arrows: fonts ← shaping -->
-  <line x1="460" y1="196" x2="460" y2="165" stroke="#94A3B8" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <!-- types → core -->
+  <line x1="168" y1="261" x2="226" y2="261" stroke="#94A3B8" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="177" y="254" font-size="10" fill="#94A3B8">imports</text>
 
-  <!-- Arrows: shaping ← worker -->
-  <line x1="576" y1="185" x2="524" y2="215" stroke="#94A3B8" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <!-- core ← fonts -->
+  <line x1="464" y1="227" x2="410" y2="244" stroke="#94A3B8" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="418" y="222" font-size="10" fill="#94A3B8">imports</text>
 
-  <!-- Arrows: crypto → core (dashed, standalone) -->
-  <line x1="240" y1="287" x2="255" y2="245" stroke="#10B981" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#arrow)"/>
+  <!-- fonts ← shaping -->
+  <line x1="533" y1="296" x2="533" y2="262" stroke="#94A3B8" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="538" y="283" font-size="10" fill="#94A3B8">imports</text>
 
-  <!-- Arrows: parser → core (dashed, imports compress) -->
-  <line x1="400" y1="290" x2="320" y2="245" stroke="#F97316" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#arrow)"/>
+  <!-- shaping ← worker -->
+  <line x1="660" y1="278" x2="602" y2="313" stroke="#94A3B8" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="626" y="285" font-size="10" fill="#94A3B8">imports</text>
 
-  <!-- Labels on arrows -->
-  <text x="148" y="162" font-size="9" fill="#94A3B8">imports</text>
-  <text x="365" y="122" font-size="9" fill="#94A3B8">imports</text>
-  <text x="467" y="184" font-size="9" fill="#94A3B8">imports</text>
-  <text x="550" y="196" font-size="9" fill="#94A3B8">imports</text>
-  <text x="210" y="270" font-size="9" fill="#10B981">standalone</text>
-  <text x="355" y="270" font-size="9" fill="#F97316">imports compress</text>
+  <!-- crypto → core (dashed, standalone) -->
+  <line x1="295" y1="408" x2="297" y2="348" stroke="#10B981" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#arrow-green)"/>
+  <text x="302" y="382" font-size="10" fill="#10B981">standalone</text>
+
+  <!-- parser → core (dashed, imports compress) -->
+  <line x1="490" y1="408" x2="380" y2="348" stroke="#F97316" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#arrow-orange)"/>
+  <text x="406" y="393" font-size="10" fill="#F97316">imports compress</text>
 </svg>

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -97,3 +97,27 @@ types/ → core/ ← fonts/ ← shaping/ ← worker/
 | Shared assembler | `pdf-assembler.ts` eliminates xref/trailer duplication between builders |
 | Extracted renderers | `pdf-renderers.ts` — block renderers, text wrapping, constants extracted from `pdf-document.ts` for maintainability |
 | Encoding context in core/ | Dependency inversion — breaks fonts/ → shaping/ cycle |
+
+## Ecosystem
+
+The architecture diagram above shows the **internal library modules**. External consumers sit above the library and import from `pdfnative` like any npm package.
+
+### pdfnative-mcp
+
+[pdfnative-mcp](https://github.com/Nizoka/pdfnative-mcp) is the primary ecosystem consumer: a **Model Context Protocol server** that wraps the pdfnative public API and exposes it as 8 structured tools to any MCP-compatible AI client (Claude Desktop, Cursor, Continue, Zed, ChatGPT, …).
+
+```
+[Claude Desktop / Cursor / Continue / Zed]
+              │ MCP stdio protocol
+     ┌──────────────────────└
+     │  pdfnative-mcp (npm)   │  ← MCP server, 8 tools
+     └──────────────────────┘
+              │ import { buildDocumentPDFBytes, … } from 'pdfnative'
+     ┌──────────────────────└
+     │      pdfnative (npm)      │  ← core library (this repo)
+     └──────────────────────┘
+```
+
+pdfnative-mcp is **not an internal module** — it is a separate npm package with its own repository, versioning, and release cadence. It references `pdfnative` only through the public API.
+
+For setup instructions, tool reference, and per-client configuration, see the [MCP Integration Guide](mcp.html).

--- a/docs/guides/index.html
+++ b/docs/guides/index.html
@@ -68,6 +68,10 @@
         <a href="pdfa.html">PDF/A conformance →</a>
         <span class="guide-toc-desc">PDF/A-1b, 2b, 2u, 3b — current status, veraPDF validation workflow, and the v1.0.5 Latin-embedding roadmap.</span>
       </li>
+      <li>
+        <a href="mcp.html">MCP Integration →</a>
+        <span class="guide-toc-desc">Use pdfnative from Claude Desktop, Cursor, Continue, and Zed via pdfnative-mcp — 8 tools, per-client configuration, security model, and a signed-document workflow.</span>
+      </li>
     </ul>
 
     <h2>Looking for samples?</h2>

--- a/docs/guides/mcp.html
+++ b/docs/guides/mcp.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>MCP Integration Guide — pdfnative</title>
+  <meta name="description" content="Use pdfnative from any AI client (Claude Desktop, Cursor, Continue, Zed) via the pdfnative-mcp Model Context Protocol server — 8 production-grade PDF tools.">
+  <link rel="canonical" href="https://pdfnative.dev/guides/mcp.html">
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+  <link rel="stylesheet" href="../style.css">
+  <link rel="stylesheet" href="guide.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-tomorrow.min.css">
+</head>
+<body>
+
+<nav class="nav" role="navigation" aria-label="Main navigation">
+  <div class="nav-inner">
+    <a class="nav-brand" href="../">
+      <img src="../assets/logo.svg" alt="" width="28" height="28">
+      pdfnative
+    </a>
+    <button class="nav-hamburger" aria-label="Toggle menu" aria-expanded="false">☰</button>
+    <ul class="nav-links" role="list">
+      <li><a href="../#features">Features</a></li>
+      <li><a href="../#examples">Examples</a></li>
+      <li><a href="../#demo">Demo</a></li>
+      <li><a href="../#mcp">MCP</a></li>
+      <li><a href="./">Guides</a></li>
+      <li><a href="https://github.com/Nizoka/pdfnative" target="_blank" rel="noopener">GitHub</a></li>
+      <li><button class="theme-toggle" aria-label="Toggle dark mode">🌙</button></li>
+    </ul>
+  </div>
+</nav>
+
+<main class="guide-shell">
+  <p class="guide-breadcrumb"><a href="../">Home</a> &nbsp;›&nbsp; <a href="./">Guides</a> &nbsp;›&nbsp; MCP Integration</p>
+  <article id="guide-content" class="guide-content" data-md="mcp.md">
+    <p class="guide-loading">Loading…</p>
+  </article>
+</main>
+
+<footer class="footer">
+  <div class="footer-inner">
+    <span>MIT License · © 2026 Nizoka</span>
+    <ul class="footer-links" role="list">
+      <li><a href="https://github.com/Nizoka/pdfnative" target="_blank" rel="noopener">GitHub</a></li>
+      <li><a href="https://www.npmjs.com/package/pdfnative" target="_blank" rel="noopener">npm</a></li>
+      <li><a href="https://github.com/Nizoka/pdfnative/blob/main/CHANGELOG.md" target="_blank" rel="noopener">Changelog</a></li>
+      <li><a href="./">All guides</a></li>
+    </ul>
+  </div>
+</footer>
+
+<script src="https://cdn.jsdelivr.net/npm/marked@12.0.2/marked.min.js" defer></script>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.5/dist/purify.min.js" defer></script>
+<script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/prism.min.js" defer></script>
+<script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-typescript.min.js" defer></script>
+<script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-bash.min.js" defer></script>
+<script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-json.min.js" defer></script>
+<script src="guide.js" defer></script>
+</body>
+</html>

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -1,0 +1,384 @@
+# pdfnative-mcp — AI Client Integration Guide
+
+[pdfnative-mcp](https://github.com/Nizoka/pdfnative-mcp) is an **MCP server** that exposes the full pdfnative library to any AI client supporting the [Model Context Protocol](https://modelcontextprotocol.io) — Claude Desktop, Cursor, Continue, Zed, ChatGPT, and more.
+
+> **What is MCP?** The Model Context Protocol is an open standard (originally developed by Anthropic) that lets AI assistants call external tools in a structured, safe way. An MCP server declares a set of tools with typed inputs and outputs; the AI client invokes those tools on your behalf during a conversation.
+
+With `pdfnative-mcp` installed, you can say to your AI assistant:
+
+> _"Generate a Q1 2026 financial report as PDF with a QR code pointing to our dashboard"_
+
+…and the AI will call the right combination of `generate_basic_pdf`, `add_barcode`, or `add_table` tools, returning a ready-to-download PDF.
+
+---
+
+## Installation
+
+```bash
+# Run directly with npx — no global install required (recommended)
+npx -y pdfnative-mcp
+
+# Or install globally
+npm install -g pdfnative-mcp
+pdfnative-mcp
+```
+
+**Requirements:** Node.js ≥ 22.
+
+---
+
+## Configuration by client
+
+### Claude Desktop
+
+Edit the config file for your OS:
+
+- **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "pdfnative": {
+      "command": "npx",
+      "args": ["-y", "pdfnative-mcp"],
+      "env": {
+        "PDFNATIVE_MPC_OUTPUT_DIR": "/Users/you/Documents/mcp-pdfs"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop after saving. The `pdfnative` server will appear in the tools panel.
+
+### Cursor
+
+In your project `.cursor/mcp.json` (or global `~/.cursor/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "pdfnative": {
+      "command": "npx",
+      "args": ["-y", "pdfnative-mcp"],
+      "env": {
+        "PDFNATIVE_MPC_OUTPUT_DIR": "/path/to/pdf-output"
+      }
+    }
+  }
+}
+```
+
+### Continue
+
+In your `~/.continue/config.json`:
+
+```json
+{
+  "mcpServers": [
+    {
+      "name": "pdfnative",
+      "command": "npx",
+      "args": ["-y", "pdfnative-mcp"],
+      "env": {
+        "PDFNATIVE_MPC_OUTPUT_DIR": "/path/to/pdf-output"
+      }
+    }
+  ]
+}
+```
+
+### Zed
+
+In your Zed `settings.json`:
+
+```json
+{
+  "context_servers": {
+    "pdfnative": {
+      "command": {
+        "path": "npx",
+        "args": ["-y", "pdfnative-mcp"],
+        "env": {
+          "PDFNATIVE_MPC_OUTPUT_DIR": "/path/to/pdf-output"
+        }
+      }
+    }
+  }
+}
+```
+
+---
+
+## Environment variables
+
+| Variable | Purpose |
+|---|---|
+| `PDFNATIVE_MPC_OUTPUT_DIR` | Absolute path to the sandbox directory. **Required to enable `outputMode: "file"`**. When unset, only `base64` output is available. |
+| `PDFNATIVE_MCP_PORT` | When set to a valid port (1–65535), starts an HTTP server on `http://127.0.0.1:<port>/mcp` instead of stdio. |
+
+---
+
+## Tool reference
+
+`pdfnative-mcp` exposes **8 tools**:
+
+| Tool | Purpose |
+|---|---|
+| `generate_basic_pdf` | Multi-page A4 documents from structured blocks (headings, paragraphs, lists, page breaks) |
+| `add_table` | Tabular PDF reports from column headers and data rows |
+| `add_barcode` | QR Code, Code 128, EAN-13, Data Matrix, PDF417 — embedded in a single-page PDF |
+| `add_international_text` | 16 non-Latin scripts (Arabic, Thai, CJK, Devanagari, Bengali, Tamil, …) with BiDi & OpenType shaping |
+| `add_form` | Interactive AcroForm PDFs with text fields, checkboxes, radio buttons, and dropdowns |
+| `embed_image` | Embed a JPEG or PNG image (base64-encoded) into a titled PDF document |
+| `prepare_signature_placeholder` | Create a PDF with a `/Sig` AcroForm placeholder ready to be signed |
+| `sign_pdf` | PAdES-style CMS digital signatures (RSA-SHA256 / ECDSA-SHA256 P-256) |
+
+---
+
+### `generate_basic_pdf`
+
+Produces a multi-page document from a list of content blocks.
+
+```jsonc
+{
+  "title": "Q1 2026 Report",
+  "blocks": [
+    { "type": "heading",   "text": "Executive Summary", "level": 1 },
+    { "type": "paragraph", "text": "Revenue grew 24 % year over year." },
+    { "type": "list",      "style": "bullet", "items": ["Strong APAC", "Stable EU", "Soft NA"] },
+    { "type": "pageBreak" },
+    { "type": "heading",   "text": "Details", "level": 2 }
+  ],
+  "footerText": "Confidential — Internal use only",
+  "outputMode": "base64"
+}
+```
+
+**Block types supported:** `heading` (levels 1–3), `paragraph`, `list` (`bullet` / `numbered`), `pageBreak`.
+
+---
+
+### `add_table`
+
+Generates a tabular report from column headers and rows.
+
+```jsonc
+{
+  "title": "Monthly Sales",
+  "headers": ["Region", "Units", "Revenue"],
+  "rows": [
+    ["APAC", "1 200", "$240,000"],
+    ["EMEA", "800",   "$160,000"]
+  ],
+  "infoItems":  [{ "label": "Period", "value": "January 2026" }],
+  "footerText": "Internal use only",
+  "outputMode": "base64"
+}
+```
+
+---
+
+### `add_barcode`
+
+```jsonc
+{
+  "format":     "qr",
+  "data":       "https://pdfnative.dev",
+  "caption":    "Scan to learn more",
+  "ecLevel":    "H",
+  "outputMode": "file",
+  "outputPath": "tickets/event-42.pdf"
+}
+```
+
+**Supported formats:** `qr`, `code128`, `ean13`, `datamatrix`, `pdf417`.  
+**Error correction levels** (QR only): `L`, `M`, `Q`, `H`.
+
+---
+
+### `add_international_text`
+
+```jsonc
+{
+  "title":      "مرحبا بالعالم",
+  "lang":       "ar",
+  "paragraphs": [
+    "هذا اختبار للنص العربي مع تشكيل OpenType ومحارف ثنائية الاتجاه.",
+    "Mixed content: العربية + English ✓"
+  ]
+}
+```
+
+**Supported `lang` codes:** `ar` (Arabic), `he` (Hebrew), `th` (Thai), `ja` (Japanese), `zh` (Chinese Simplified), `ko` (Korean), `el` (Greek), `hi` (Devanagari/Hindi), `bn` (Bengali), `ta` (Tamil), `ru` (Cyrillic/Russian), `ka` (Georgian), `hy` (Armenian), `tr` (Turkish), `vi` (Vietnamese), `pl` (Polish).
+
+---
+
+### `add_form`
+
+Creates an interactive AcroForm PDF.
+
+```jsonc
+{
+  "title": "Employee Onboarding",
+  "fields": [
+    { "fieldType": "text",     "name": "fullName", "label": "Full Name",   "required": true },
+    { "fieldType": "dropdown", "name": "dept",     "label": "Department",  "options": ["Engineering", "Sales", "HR"] },
+    { "fieldType": "checkbox", "name": "agree",    "label": "I agree to the terms", "checked": false }
+  ],
+  "outputMode": "base64"
+}
+```
+
+**Field types:** `text`, `multiline`, `checkbox`, `radio`, `dropdown`, `listbox`.
+
+---
+
+### `embed_image`
+
+```jsonc
+{
+  "title":       "Product Photo",
+  "imageBase64": "<base64-encoded JPEG bytes>",
+  "mimeType":    "image/jpeg",
+  "caption":     "Front view of Model X",
+  "width":       400,
+  "outputMode":  "base64"
+}
+```
+
+> **Note:** Alpha-channel PNGs (color type 6) are not supported. Pre-process such images to remove the alpha channel before embedding.
+
+---
+
+### `prepare_signature_placeholder`
+
+Creates a PDF pre-wired with an AcroForm `/Sig` field, ready to be signed by `sign_pdf`.
+
+```jsonc
+{
+  "title":      "Service Agreement",
+  "signerName": "Alice Dupont",
+  "reason":     "Approved",
+  "location":   "Paris, FR",
+  "blocks": [
+    { "type": "paragraph", "text": "By signing below, I accept the terms and conditions." }
+  ],
+  "outputMode": "base64"
+}
+```
+
+---
+
+### `sign_pdf`
+
+Signs a PDF that already contains a `/Sig` placeholder (produced by `prepare_signature_placeholder`).
+
+```jsonc
+{
+  "pdfBase64":           "<base64 PDF bytes>",
+  "algorithm":           "rsa-sha256",
+  "certDerBase64":       "<base64 X.509 certificate in DER format>",
+  "rsaKeyPkcs1DerBase64":"<base64 PKCS#1 RSAPrivateKey in DER format>",
+  "signerName":          "Alice",
+  "reason":              "Approval",
+  "location":            "Paris, FR",
+  "signingTime":         "2026-01-15T10:30:00Z"
+}
+```
+
+For ECDSA P-256: use `"algorithm": "ecdsa-sha256"` and supply `ecPrivateScalarHex` (64 hex chars) instead of `rsaKeyPkcs1DerBase64`.
+
+---
+
+## Output modes
+
+Every tool accepts an `outputMode` field:
+
+| Mode | Behaviour |
+|---|---|
+| `"base64"` *(default)* | The PDF bytes are returned inline in the MCP response as a base64 string. Suitable for pipelines that immediately consume or display the bytes. |
+| `"file"` | The PDF is written to the sandbox directory configured via `PDFNATIVE_MPC_OUTPUT_DIR`. An `outputPath` (relative, `.pdf` extension) is required. **Disabled unless the environment variable is set.** |
+
+---
+
+## End-to-end example: signed document
+
+This workflow uses two tools in sequence:
+
+```jsonc
+// Step 1 — create the placeholder
+{
+  "tool": "prepare_signature_placeholder",
+  "input": {
+    "title":      "Purchase Order #42",
+    "signerName": "Jane Smith",
+    "reason":     "CFO approval",
+    "location":   "London, UK",
+    "blocks": [
+      { "type": "paragraph", "text": "Total amount: $128,000" }
+    ],
+    "outputMode": "base64"
+  }
+}
+
+// Step 2 — sign the returned PDF
+{
+  "tool": "sign_pdf",
+  "input": {
+    "pdfBase64":            "<result from step 1>",
+    "algorithm":            "rsa-sha256",
+    "certDerBase64":        "<your DER certificate>",
+    "rsaKeyPkcs1DerBase64": "<your PKCS#1 private key>",
+    "signerName":           "Jane Smith",
+    "reason":               "CFO approval",
+    "location":             "London, UK",
+    "signingTime":          "2026-04-26T09:00:00Z",
+    "outputMode":           "base64"
+  }
+}
+```
+
+---
+
+## Security model
+
+`pdfnative-mcp` is designed to run safely inside your AI client:
+
+- **No network access** — the server does not open outbound connections.
+- **Sandboxed file writes** — `file` output mode is gated by `PDFNATIVE_MPC_OUTPUT_DIR`. When unset, file writes are rejected with a `SecurityError`.
+- **Path traversal protection** — absolute paths, `..` sequences, NUL bytes, and non-`.pdf` extensions are all rejected.
+- **Output size cap** — PDF output is capped at **50 MB** per call.
+- **Input validation** — every tool validates inputs against strict JSON Schemas and Zod runtime checks at the boundary.
+
+See [SECURITY.md](https://github.com/Nizoka/pdfnative-mcp/blob/main/SECURITY.md) for responsible disclosure.
+
+---
+
+## Troubleshooting
+
+**The server does not appear in my AI client.**  
+Verify that Node.js ≥ 22 is installed (`node --version`) and that the config file path is correct for your OS. Restart the client after any config change.
+
+**`file` output mode returns a SecurityError.**  
+Set the `PDFNATIVE_MPC_OUTPUT_DIR` environment variable to an existing absolute path in the client config.
+
+**`add_international_text` produces blank text.**  
+The required Noto font is downloaded lazily on first use. Ensure the process has network access (or pre-install `pdfnative` with fonts cached).
+
+**`sign_pdf` fails with "invalid placeholder".**  
+Pass a PDF produced by `prepare_signature_placeholder`. The placeholder must not have been modified since creation.
+
+**Output PDF exceeds 50 MB.**  
+Split the content across multiple tool calls or reduce image/barcode count.
+
+---
+
+## Further reading
+
+- [pdfnative-mcp on GitHub](https://github.com/Nizoka/pdfnative-mcp) — source, issues, CHANGELOG
+- [pdfnative-mcp on npm](https://www.npmjs.com/package/pdfnative-mcp) — version history, install stats
+- [pdfnative Quick Start](quickstart.html) — pdfnative library directly in Node.js / browser
+- [Architecture guide](architecture.html) — how pdfnative-mcp sits in the ecosystem
+- [Model Context Protocol specification](https://modelcontextprotocol.io) — MCP standard reference

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>pdfnative — Zero-dependency PDF generation for TypeScript</title>
   <meta name="description" content="Pure native PDF generation library with zero dependencies. ISO 32000-1 compliant. 16 Unicode scripts. TypeScript-first. PDF/A, encryption, digital signatures, barcodes, SVG, forms, streaming.">
-  <meta name="keywords" content="pdf, typescript, javascript, pdf generation, zero dependencies, unicode, arabic, thai, pdf/a, encryption, digital signatures, barcodes, svg, acroform">
+  <meta name="keywords" content="pdf, typescript, javascript, pdf generation, zero dependencies, unicode, arabic, thai, pdf/a, encryption, digital signatures, barcodes, svg, acroform, mcp, model-context-protocol, claude, cursor, ai, llm">
 
   <!-- Open Graph -->
   <meta property="og:type" content="website">
@@ -63,6 +63,7 @@
       <li><a href="#comparison">Compare</a></li>
       <li><a href="#benchmarks">Benchmarks</a></li>
       <li><a href="#architecture">Architecture</a></li>
+      <li><a href="#mcp">MCP</a></li>
       <li><a href="guides/">Guides</a></li>
       <li><a href="playgrounds/extreme-scripts.html">Playgrounds</a></li>
       <li><a href="https://github.com/Nizoka/pdfnative" target="_blank" rel="noopener">GitHub</a></li>
@@ -175,6 +176,12 @@
         <div class="feature-icon fi-production"><svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg></div>
         <h3>Production Ready</h3>
         <p>AsyncGenerator streaming, Web Worker off-thread generation, PDF parser &amp; modifier. 1 588+ tests, 95%+ coverage, SLSA provenance.</p>
+      </div>
+
+      <div class="feature-card">
+        <div class="feature-icon fi-mcp"><svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/><path d="M7 8h2M15 8h2M11 8h2"/></svg></div>
+        <h3>AI Integration — MCP</h3>
+        <p>Use pdfnative from Claude Desktop, Cursor, Continue, and Zed via <a href="https://github.com/Nizoka/pdfnative-mcp" target="_blank" rel="noopener">pdfnative-mcp</a>. 8 production tools, zero configuration beyond <code>npx -y pdfnative-mcp</code>.</p>
       </div>
 
     </div>
@@ -533,8 +540,46 @@ const pdf = buildDocumentPDFBytes({
     <p class="section-subtitle">Strict unidirectional dependency flow. No circular imports. Each module is independently testable.</p>
     <div class="arch-diagram">
       <a href="https://github.com/Nizoka/pdfnative/tree/master/src" target="_blank" rel="noopener">
-        <img src="assets/architecture.svg" alt="pdfnative module architecture: types → core ← fonts ← shaping ← worker, with standalone crypto and parser modules" width="800" height="360" loading="lazy">
+        <img src="assets/architecture.svg" alt="pdfnative module architecture: pdfnative-mcp ecosystem consumer above the library, types → core ← fonts ← shaping ← worker, with standalone crypto and parser modules" width="960" height="540" loading="lazy">
       </a>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════ MCP ═══════════════ -->
+<section class="section section-alt" id="mcp">
+  <div class="container">
+    <h2 class="section-title">Use pdfnative from Any AI Client</h2>
+    <p class="section-subtitle"><a href="https://github.com/Nizoka/pdfnative-mcp" target="_blank" rel="noopener">pdfnative-mcp</a> is a <strong>Model Context Protocol server</strong> that exposes the full pdfnative library to Claude Desktop, Cursor, Continue, Zed, and any other MCP-compatible AI client. One <code>npx</code> command, no code required.</p>
+    <div class="mcp-layout">
+      <div class="mcp-tools">
+        <h3>8 Production Tools</h3>
+        <table class="mcp-table">
+          <thead><tr><th>Tool</th><th>Purpose</th></tr></thead>
+          <tbody>
+            <tr><td><code>generate_basic_pdf</code></td><td>Multi-page documents (headings, paragraphs, lists)</td></tr>
+            <tr><td><code>add_table</code></td><td>Tabular reports from headers and rows</td></tr>
+            <tr><td><code>add_barcode</code></td><td>QR Code, Code 128, EAN-13, Data Matrix, PDF417</td></tr>
+            <tr><td><code>add_international_text</code></td><td>16 scripts with BiDi &amp; OpenType shaping</td></tr>
+            <tr><td><code>add_form</code></td><td>Interactive AcroForm fields</td></tr>
+            <tr><td><code>embed_image</code></td><td>JPEG / PNG image embedding</td></tr>
+            <tr><td><code>prepare_signature_placeholder</code></td><td>PDF with <code>/Sig</code> field ready to sign</td></tr>
+            <tr><td><code>sign_pdf</code></td><td>CMS/PKCS#7 signatures (RSA &amp; ECDSA)</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="mcp-config">
+        <h3>Claude Desktop — 3-line setup</h3>
+<pre><code class="language-json">{
+  "mcpServers": {
+    "pdfnative": {
+      "command": "npx",
+      "args": ["-y", "pdfnative-mcp"]
+    }
+  }
+}</code></pre>
+        <p>Supports Cursor, Continue, Zed, and any stdio MCP client. See the <a href="guides/mcp.html">MCP Integration Guide →</a></p>
+      </div>
     </div>
   </div>
 </section>
@@ -573,6 +618,7 @@ const pdf = buildDocumentPDFBytes({
       <li><a href="guides/troubleshooting.html">Troubleshooting</a></li>
       <li><a href="guides/accessibility.html">Accessibility</a></li>
       <li><a href="guides/pdfa.html">PDF/A</a></li>
+      <li><a href="guides/mcp.html">MCP Integration</a></li>
       <li><a href="playgrounds/extreme-scripts.html">Extreme scripts playground</a></li>
       <li><a href="playgrounds/medical-800.html">Medical 800-page playground</a></li>
       <li><a href="https://plika.app" target="_blank" rel="noopener">Originally from Plika.app</a></li>

--- a/docs/style.css
+++ b/docs/style.css
@@ -236,6 +236,7 @@ img, svg { max-width: 100%; height: auto; }
 .fi-security { background: #fee2e2; color: #dc2626; }
 .fi-content { background: #ffedd5; color: #ea580c; }
 .fi-production { background: #fef3c7; color: #d97706; }
+.fi-mcp { background: #eef2ff; color: #4338ca; }
 
 /* ── Code Tabs ─────────────────────────────────────────────── */
 .code-tabs { max-width: 780px; margin: 0 auto; }
@@ -360,8 +361,57 @@ img, svg { max-width: 100%; height: auto; }
 .bench-note { text-align: center; font-size: 12px; color: var(--c-text-muted); margin-top: 24px; }
 
 /* ── Architecture ──────────────────────────────────────────── */
-.arch-diagram { max-width: 700px; margin: 0 auto; }
+.arch-diagram { max-width: 860px; margin: 0 auto; }
 .arch-diagram svg { width: 100%; height: auto; }
+
+/* ── MCP section ───────────────────────────────────────────── */
+.mcp-layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 40px;
+  margin-top: 40px;
+  align-items: start;
+}
+.mcp-layout h3 { font-size: 18px; font-weight: 700; margin-bottom: 16px; }
+.mcp-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+.mcp-table th {
+  text-align: left;
+  padding: 8px 10px;
+  border-bottom: 2px solid var(--c-border);
+  font-weight: 700;
+  color: var(--c-text-dim);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: .05em;
+}
+.mcp-table td {
+  padding: 7px 10px;
+  border-bottom: 1px solid var(--c-border);
+  vertical-align: top;
+  line-height: 1.5;
+}
+.mcp-table tr:last-child td { border-bottom: none; }
+.mcp-table td:first-child code {
+  font-size: 12px;
+  white-space: nowrap;
+  background: var(--c-code-bg, rgba(99,102,241,.08));
+  padding: 2px 6px;
+  border-radius: 4px;
+  color: #6366F1;
+}
+.mcp-config pre {
+  font-size: 13px;
+  border-radius: 8px;
+  overflow-x: auto;
+}
+.mcp-config p { margin-top: 16px; font-size: 14px; }
+@media (max-width: 900px) {
+  .mcp-layout { grid-template-columns: 1fr; }
+}
 
 /* ── Origin ────────────────────────────────────────────────── */
 .origin {


### PR DESCRIPTION
…es, and architecture diagram

- README.md: add pdfnative-mcp npm badge, AI integration highlight bullet, and new Ecosystem section with tool table + Claude Desktop config snippet
- docs/index.html: add MCP nav link, MCP feature card (fi-mcp), new #mcp section with tools table + config snippet, footer link, updated meta keywords
- docs/style.css: add .fi-mcp icon color, .mcp-layout grid, .mcp-table styles, increase .arch-diagram max-width to 860px for new SVG dimensions
- docs/assets/architecture.svg: full redesign — 960x540 canvas, title/desc accessibility, improved font sizes, ECOSYSTEM zone with pdfnative-mcp box, PDFNATIVE LIBRARY zone, consistent arrowheads and spacing
- docs/guides/mcp.md: new full MCP integration guide (installation, per-client config, 8 tool reference with examples, output modes, signed-document workflow, security model, troubleshooting)
- docs/guides/mcp.html: HTML shell for mcp.md following guide page pattern
- docs/guides/index.html: add MCP Integration entry to TOC list
- docs/guides/architecture.md: add Ecosystem section with pdfnative-mcp consumer diagram and link to MCP guide
- ROADMAP.md: add pdfnative-mcp to Released section
- release-notes/draft-issue-docs-mcp-integration.md: GitHub issue draft with full checklist for copy-paste

## Description

Documents the `pdfnative-mcp` ecosystem package across all documentation surfaces: README, landing page, guides, and the architecture diagram.

**Why:** `pdfnative-mcp` (https://github.com/Nizoka/pdfnative-mcp) is published and working (v0.2.0, 8 tools). The pdfnative documentation contained no reference to it, leaving Claude Desktop / Cursor / Continue / Zed users with no path to discovery.

**What changed (documentation only — no source code):**

- **`docs/guides/mcp.md` + `docs/guides/mcp.html`** — new full MCP Integration Guide: what is MCP, per-client configuration (Claude Desktop macOS/Windows, Cursor, Continue, Zed), reference for all 8 tools with example JSON, output modes, signed-document 2-step workflow, security model, and troubleshooting
- **`README.md`** — `pdfnative-mcp` npm badge, AI integration highlight bullet, new `## Ecosystem` section with tool table and Claude Desktop config snippet
- **`docs/index.html`** — `MCP` nav link (`#mcp`), "AI Integration — MCP" feature card, new `#mcp` section (tools table + config snippet), footer guide link, updated `<meta keywords>`
- **`docs/style.css`** — `.fi-mcp` icon color, `.mcp-layout` 2-column grid, `.mcp-table` styles, `arch-diagram` max-width bumped to 860 px
- **`docs/assets/architecture.svg`** — redesign: 960×540 canvas, `<title>`/`<desc>` accessibility, ECOSYSTEM zone with `pdfnative-mcp` consumer box (indigo), PDFNATIVE LIBRARY zone, improved font sizes and arrowheads
- **`docs/guides/index.html`** — "MCP Integration →" entry in the TOC list
- **`docs/guides/architecture.md`** — `## Ecosystem` section with ASCII consumer diagram and link to the MCP guide
- **`ROADMAP.md`** — `pdfnative-mcp` entry under `## Released`
- **`release-notes/draft-issue-docs-mcp-integration.md`** — GitHub issue draft for tracking

## Related Issues

Closes #<!-- insert issue number after opening the draft issue from draft-issue-docs-mcp-integration.md -->

## Checklist

- [ ] Tests pass (`npm run test`) — _N/A: no source code changes_
- [ ] Type check passes (`npm run typecheck:all`) — _N/A: no source code changes_
- [ ] Lint passes (`npm run lint`) — _N/A: no source code changes_
- [ ] New code has tests (coverage thresholds must not regress) — _N/A: documentation only_
- [ ] CHANGELOG.md updated (if user-facing change) — _N/A: pdfnative-mcp has its own CHANGELOG_
- [x] No breaking changes (or documented in description) — ✅ documentation only, no API changes

Closes #30 