### PR TITLE
docs: add playgrounds and align with pdfnative-cli v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -814,20 +814,31 @@ pdfnative ships as a library, but two official companion packages cover the most
 
 ### pdfnative-cli — command-line interface
 
-[`pdfnative-cli`](https://github.com/Nizoka/pdfnative-cli) is the **official CLI**. It exposes three commands — `render`, `sign`, `inspect` — for use in shell scripts, Makefiles, GitHub Actions, and Docker images. Zero extra runtime dependencies, npm-provenance-signed.
+[`pdfnative-cli`](https://github.com/Nizoka/pdfnative-cli) v0.2.0 is the **official CLI**. It exposes four commands — `render`, `sign`, `inspect`, **`verify`** — covering the full `pdfnative` v1.0.5 surface for use in shell scripts, Makefiles, GitHub Actions, and Docker images. Zero extra runtime dependencies, npm-provenance-signed.
+
+**Highlights (v0.2.0):** hybrid `flags + --layout file.json` model, encryption (AES-128/256), watermarks (text + image), header/footer page templates with `{page}/{pages}/{date}/{title}`, PDF/A-3 attachments (Factur-X / ZUGFeRD pattern), multilingual fonts via `--lang`, table-variant rendering, signing metadata + intermediate cert chains, `inspect --verbose/--pages/--check`, and a brand-new `verify` command for byte-range integrity and certificate-chain validation. **100 % backward-compatible** with v0.1.0.
 
 ```bash
-# render a JSON document spec to PDF
-npx pdfnative-cli render document.json --output report.pdf
+# render with full layout coverage (encryption + watermark + PDF/A-2b)
+npx pdfnative-cli render --input doc.json --output report.pdf \
+  --tagged pdfa2b --compress \
+  --watermark-text "DRAFT" --watermark-opacity 0.15
 
-# sign an existing PDF (RSA or ECDSA, CMS/PKCS#7)
-npx pdfnative-cli sign report.pdf --cert cert.pem --key key.pem --output signed.pdf
+# sign with metadata and intermediate cert chain
+npx pdfnative-cli sign --input report.pdf --output signed.pdf \
+  --reason "Approved" --name "Finance Team" \
+  --signing-time 2026-04-28T10:00:00Z \
+  --cert-chain intermediate.pem
 
-# inspect a PDF (page count, metadata, fonts, signatures)
-npx pdfnative-cli inspect signed.pdf
+# verify embedded signatures (byte-range + chain + trust)
+npx pdfnative-cli verify --input signed.pdf --strict --trust ca-root.pem
+
+# inspect with CI assertions (exit 1 on failure)
+npx pdfnative-cli inspect --input signed.pdf \
+  --check pdfa --check signed --format json
 ```
 
-See the [CLI Guide](https://pdfnative.dev/guides/cli.html) for full reference, security model, and pipeline examples.
+See the [CLI Guide](https://pdfnative.dev/guides/cli.html) for the full v0.2.0 reference, security model, recipes, and the `--conformance` → `--tagged` migration path. Try the [interactive CLI playground](https://pdfnative.dev/playgrounds/cli.html) to build commands without leaving the browser.
 
 ### pdfnative-mcp — Model Context Protocol server
 

--- a/docs/assets/architecture.svg
+++ b/docs/assets/architecture.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 540" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif">
   <title>pdfnative — Module Architecture</title>
-  <desc>Dependency diagram showing pdfnative's internal modules (core, fonts, shaping, worker, crypto, parser, types) and the external ecosystem consumers: pdfnative-cli (command-line interface) and pdfnative-mcp (MCP server).</desc>
+  <desc>Dependency diagram showing pdfnative's internal modules (core, fonts, shaping, worker, crypto, parser, types) and the external ecosystem consumers: pdfnative-cli (command-line interface with 4 commands: render, sign, inspect, verify) and pdfnative-mcp (Model Context Protocol server with 8 tools, compatible with Claude Desktop, Cursor, Zed, and any other stdio MCP client). Shaping covers GSUB, GPOS, BiDi, and 16 scripts. Crypto and parser are standalone modules.</desc>
 
   <defs>
     <marker id="arrow" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="7" markerHeight="5" orient="auto-start-reverse">
@@ -35,14 +35,14 @@
   <!-- pdfnative-cli box -->
   <rect x="175" y="72" width="250" height="68" rx="10" fill="#ECFEFF" stroke="#0E7490" stroke-width="2" filter="url(#shadow)"/>
   <text x="300" y="100" text-anchor="middle" font-size="15" font-weight="700" fill="#155E75">pdfnative-cli</text>
-  <text x="300" y="118" text-anchor="middle" font-size="11" fill="#0E7490">CLI · 3 commands</text>
-  <text x="300" y="132" text-anchor="middle" font-size="10" fill="#0891B2">render · sign · inspect</text>
+  <text x="300" y="118" text-anchor="middle" font-size="11" fill="#0E7490">CLI · 4 commands</text>
+  <text x="300" y="132" text-anchor="middle" font-size="10" fill="#0891B2">render · sign · inspect · verify</text>
 
   <!-- pdfnative-mcp box -->
   <rect x="535" y="72" width="250" height="68" rx="10" fill="#EEF2FF" stroke="#6366F1" stroke-width="2" filter="url(#shadow)"/>
   <text x="660" y="100" text-anchor="middle" font-size="15" font-weight="700" fill="#4338CA">pdfnative-mcp</text>
   <text x="660" y="118" text-anchor="middle" font-size="11" fill="#6366F1">MCP Server · 8 tools</text>
-  <text x="660" y="132" text-anchor="middle" font-size="10" fill="#818CF8">Claude · Cursor · Continue · Zed</text>
+  <text x="660" y="132" text-anchor="middle" font-size="10" fill="#818CF8">Claude · Cursor · Zed · any stdio client</text>
 
   <!-- ════════════════════════════════════════════════════════════ -->
   <!-- PDFNATIVE LIBRARY ZONE                                      -->
@@ -61,7 +61,7 @@
   <text x="317" y="268" text-anchor="middle" font-size="11" fill="#3B82F6">pdf-document</text>
   <text x="317" y="284" text-anchor="middle" font-size="11" fill="#3B82F6">pdf-encrypt</text>
   <text x="317" y="300" text-anchor="middle" font-size="11" fill="#3B82F6">pdf-tags</text>
-  <text x="317" y="316" text-anchor="middle" font-size="11" fill="#3B82F6">+ 12 modules</text>
+  <text x="317" y="316" text-anchor="middle" font-size="11" fill="#3B82F6">+ 13 modules</text>
 
   <!-- fonts box -->
   <rect x="468" y="196" width="130" height="62" rx="10" fill="#F3E8FF" stroke="#8B5CF6" stroke-width="1.5" filter="url(#shadow)"/>
@@ -70,7 +70,7 @@
   <!-- shaping box -->
   <rect x="468" y="298" width="130" height="64" rx="10" fill="#CCFBF1" stroke="#14B8A6" stroke-width="1.5" filter="url(#shadow)"/>
   <text x="533" y="326" text-anchor="middle" font-size="14" font-weight="600" fill="#0D9488">shaping</text>
-  <text x="533" y="345" text-anchor="middle" font-size="10" fill="#14B8A6">BiDi · Thai · Arabic</text>
+  <text x="533" y="345" text-anchor="middle" font-size="10" fill="#14B8A6">GSUB · GPOS · BiDi · 16 scripts</text>
 
   <!-- worker box -->
   <rect x="664" y="236" width="120" height="62" rx="10" fill="#FEF3C7" stroke="#F59E0B" stroke-width="1.5" filter="url(#shadow)"/>
@@ -79,7 +79,7 @@
   <!-- crypto box -->
   <rect x="230" y="410" width="130" height="62" rx="10" fill="#D1FAE5" stroke="#10B981" stroke-width="1.5" filter="url(#shadow)"/>
   <text x="295" y="437" text-anchor="middle" font-size="14" font-weight="600" fill="#059669">crypto</text>
-  <text x="295" y="455" text-anchor="middle" font-size="10" fill="#10B981">AES · RSA · ECDSA</text>
+  <text x="295" y="455" text-anchor="middle" font-size="10" fill="#10B981">AES · RSA · ECDSA · SHA · CMS</text>
 
   <!-- parser box -->
   <rect x="430" y="410" width="130" height="62" rx="10" fill="#FFEDD5" stroke="#F97316" stroke-width="1.5" filter="url(#shadow)"/>

--- a/docs/guides/accessibility.html
+++ b/docs/guides/accessibility.html
@@ -24,7 +24,10 @@
       <li><a href="../#features">Features</a></li>
       <li><a href="../#examples">Examples</a></li>
       <li><a href="../#demo">Demo</a></li>
+      <li><a href="../#mcp">MCP</a></li>
+      <li><a href="../#cli">CLI</a></li>
       <li><a href="./">Guides</a></li>
+      <li><a href="../playgrounds/">Playgrounds</a></li>
       <li><a href="https://github.com/Nizoka/pdfnative" target="_blank" rel="noopener">GitHub</a></li>
       <li><button class="theme-toggle" aria-label="Toggle dark mode">🌙</button></li>
     </ul>

--- a/docs/guides/architecture.html
+++ b/docs/guides/architecture.html
@@ -24,7 +24,10 @@
       <li><a href="../#features">Features</a></li>
       <li><a href="../#examples">Examples</a></li>
       <li><a href="../#demo">Demo</a></li>
+      <li><a href="../#mcp">MCP</a></li>
+      <li><a href="../#cli">CLI</a></li>
       <li><a href="./">Guides</a></li>
+      <li><a href="../playgrounds/">Playgrounds</a></li>
       <li><a href="https://github.com/Nizoka/pdfnative" target="_blank" rel="noopener">GitHub</a></li>
       <li><button class="theme-toggle" aria-label="Toggle dark mode">🌙</button></li>
     </ul>

--- a/docs/guides/cli.html
+++ b/docs/guides/cli.html
@@ -25,7 +25,9 @@
       <li><a href="../#examples">Examples</a></li>
       <li><a href="../#demo">Demo</a></li>
       <li><a href="../#mcp">MCP</a></li>
+      <li><a href="../#cli" aria-current="page">CLI</a></li>
       <li><a href="./">Guides</a></li>
+      <li><a href="../playgrounds/">Playgrounds</a></li>
       <li><a href="https://github.com/Nizoka/pdfnative" target="_blank" rel="noopener">GitHub</a></li>
       <li><button class="theme-toggle" aria-label="Toggle dark mode">🌙</button></li>
     </ul>

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -1,6 +1,8 @@
 # pdfnative-cli — Command-Line Interface Guide
 
-[`pdfnative-cli`](https://github.com/Nizoka/pdfnative-cli) is the **official command-line interface** for the [`pdfnative`](https://github.com/Nizoka/pdfnative) library. It exposes three commands — `render`, `sign`, `inspect` — that together cover the full document lifecycle from JSON to a signed, validated PDF.
+> **Tracks pdfnative-cli v0.2.0** (April 2026). Compatible with `pdfnative` ≥ 1.0.5. The CLI versions independently from the library — see the [release notes](https://github.com/Nizoka/pdfnative-cli/blob/main/release-notes/v0.2.0.md).
+
+[`pdfnative-cli`](https://github.com/Nizoka/pdfnative-cli) is the **official command-line interface** for the [`pdfnative`](https://github.com/Nizoka/pdfnative) library. It exposes four commands — `render`, `sign`, `inspect`, and `verify` — that together cover the full document lifecycle from JSON to a signed, verified, archive-grade PDF.
 
 > **Why a CLI?** Many real-world workflows live outside Node.js: shell scripts, CI pipelines, Docker containers, Makefiles, batch jobs, build tools written in other languages. The CLI lets all of them call `pdfnative` without writing JavaScript, and is fully composable through stdin/stdout pipelines.
 
@@ -8,11 +10,39 @@ The CLI is a **pure dispatch layer** over `pdfnative`. No PDF logic lives in the
 
 | CLI command | `pdfnative` API |
 |---|---|
-| `render` | `buildDocumentPDFBytes()` / `streamDocumentPdf()` |
+| `render` | `buildDocumentPDFBytes()` / `streamDocumentPdf()` / `buildPDFBytes()` (table variant) |
 | `sign` | `signPdfBytes()` |
 | `inspect` | `PdfReader.open()` / `getMetadata()` / `getPageCount()` |
+| `verify` | `PdfReader` + `verifyCertSignature()` (byte-range + chain) |
 
 This means **every feature of the library is one release away from the CLI**, and any bug fix in `pdfnative` is automatically picked up by `pdfnative-cli` on its next dependency bump.
+
+---
+
+## What's new in v0.2.0
+
+The v0.2.0 release expands the CLI from ~10 flags to a near-complete projection of the `pdfnative` v1.0.5 surface, while remaining **100 % backward-compatible** with v0.1.0.
+
+| Area | v0.1.0 | v0.2.0 |
+|---|---|---|
+| Layout | `--conformance` only | Hybrid model — high-frequency knobs as flags, full `PdfLayoutOptions` via `--layout file.json` |
+| PDF/A | `--conformance 1b\|2b\|3b` | `--tagged none\|pdfa1b\|pdfa2b\|pdfa2u\|pdfa3b` (`--conformance` deprecated) |
+| Encryption | — | `--encrypt-owner-pass`, `--encrypt-user-pass`, `--encrypt-algorithm`, `--encrypt-permissions` (env-var precedence) |
+| Watermarks | — | `--watermark-text`/`-image`/`-opacity`/`-angle`/`-color`/`-font-size`/`-position` |
+| Headers / footers | — | `--header-{l,c,r}`, `--footer-{l,c,r}` with `{page}/{pages}/{date}/{title}` placeholders |
+| PDF/A-3 attachments | — | `--attachment <path>[:mime[:rel[:desc]]]` (repeatable) |
+| Multilingual fonts | — | `--lang th,ja,ar` (requires `registerFontLoader()` wrapper) |
+| Renderer variant | document only | `--variant document\|table` |
+| Page geometry | — | `--page-size`, `--margin` |
+| Compression | — | `--compress` |
+| `sign` metadata | — | `--reason`, `--name`, `--location`, `--contact`, `--signing-time` |
+| `sign` cert chains | — | `--cert-chain <pem>` (repeatable) + `PDFNATIVE_SIGN_CHAIN` env |
+| `sign` algorithm | RSA implicit | `--algorithm rsa-sha256\|ecdsa-sha256` (ECDSA stub pending pdfnative `parseEcPrivateKey`, v0.3.0) |
+| `inspect` depth | basic report | `--verbose`, `--pages`, `--check pdfa\|signed\|encrypted` (composable, ANDed, exit codes) |
+| `verify` command | n/a | **NEW** — byte-range integrity + cert chain + `--trust` roots |
+| Tests | 47 | 123 |
+
+Full changelog: [pdfnative-cli release notes v0.2.0](https://github.com/Nizoka/pdfnative-cli/blob/main/release-notes/v0.2.0.md).
 
 ---
 
@@ -37,13 +67,13 @@ The CLI ships with **NPM provenance** — verify the published artifact with `np
 
 | Use the **CLI** when… | Use the **library** when… |
 |---|---|
-| You write shell scripts, Makefiles, or Bash/PowerShell pipelines | You need full control over the API surface |
-| Your CI/CD job runs in Docker or GitHub Actions | You build a Node.js / Bun / Deno service |
-| You want to compose with `cat`, `jq`, `tee`, `gzip`, etc. | You need encryption, watermarks, custom page sizes, custom headers/footers (not yet exposed via the JSON CLI) |
-| You sign or inspect PDFs ad-hoc from the terminal | You need fine-grained streaming control or Web Worker offloading |
-| You want a one-liner instead of a 30-line Node.js script | Browser, Web Worker, or Deno Deploy targets |
+| You write shell scripts, Makefiles, or Bash/PowerShell pipelines | You build a Node.js / Bun / Deno service |
+| Your CI/CD job runs in Docker or GitHub Actions | You need fine-grained streaming control or Web Worker offloading |
+| You want to compose with `cat`, `jq`, `tee`, `gzip`, etc. | You target browsers, Web Workers, or Deno Deploy |
+| You sign, verify, or inspect PDFs ad-hoc from the terminal | You bundle PDFs through a custom pipeline (custom font registry, hooks, etc.) |
+| You want a one-liner instead of a 30-line Node.js script | You need 100 % programmatic control of the API surface |
 
-The two are **complementary**. A typical full-stack project uses the library at runtime and the CLI in CI scripts.
+The two are **complementary**. A typical full-stack project uses the library at runtime and the CLI in CI scripts and operator workflows.
 
 ---
 
@@ -85,19 +115,33 @@ pdfnative render --input report.json --output report.pdf
 
 That's it — the file `report.pdf` is now a valid ISO 32000-1 PDF, ready to send.
 
-### 2. Sign the rendered PDF
+### 2. Sign the rendered PDF (with metadata)
 
 ```bash
 # Set keys via environment variables (recommended for CI/CD — never logged)
 export PDFNATIVE_SIGN_KEY="$(cat private.pem)"
 export PDFNATIVE_SIGN_CERT="$(cat cert.pem)"
 
-pdfnative sign --input report.pdf --output report.signed.pdf
+pdfnative sign \
+  --input report.pdf \
+  --output report.signed.pdf \
+  --reason "Approved by Finance" \
+  --name "Finance Team" \
+  --location "Paris, FR" \
+  --signing-time 2026-04-28T10:00:00Z
 ```
 
 The CLI accepts both **RSA PKCS#1 v1.5** and **ECDSA P-256** keys, both with SHA-256 digests. The signed PDF carries a CMS/PKCS#7 signature embedded as ISO 32000-1 §12.8 prescribes, validatable by Adobe Acrobat, MuPDF, and any other PAdES-compatible reader.
 
-### 3. Inspect any PDF
+### 3. Verify embedded signatures _(new in v0.2.0)_
+
+```bash
+pdfnative verify --input report.signed.pdf --strict --trust ca-root.pem
+```
+
+`verify` checks byte-range integrity (SHA-256 recomputed against the CMS `messageDigest` attribute), validates the certificate chain via `pdfnative`'s `verifyCertSignature`, and evaluates trust against `--trust` roots and self-signed acceptance. Exit code is 0 on success, 1 on any failure under `--strict`.
+
+### 4. Inspect any PDF
 
 ```bash
 pdfnative inspect --input report.signed.pdf --format text
@@ -111,10 +155,48 @@ PDF/A conformance:  none
 Signatures:         1
 Title:              April 2026 Report
 Author:             Finance Team
-Created:            2026-04-27T12:00:00+00:00
+Created:            2026-04-28T10:00:00+00:00
 ```
 
 JSON output (default) is suited for piping into `jq` or storing as a CI artifact.
+
+---
+
+## Hybrid layout model
+
+`render` adopts the same layout philosophy as `gh`, `kubectl`, and `docker`: high-frequency knobs are first-class flags, while the full `PdfLayoutOptions` shape is reachable via a JSON layout file.
+
+**Precedence:** `CLI flags > --layout file > pdfnative defaults`.
+
+```bash
+# 1) Flags only — best for ad-hoc invocations
+pdfnative render --input doc.json --output report.pdf \
+  --page-size A4 --margin 50 --compress --tagged pdfa2b
+
+# 2) Layout file only — best for reproducible CI configs
+pdfnative render --input doc.json --output report.pdf \
+  --layout layout.json
+
+# 3) Hybrid — base config in a file, per-job overrides on the CLI
+pdfnative render --input doc.json --output report.pdf \
+  --layout layout.json \
+  --watermark-text "DRAFT $(date +%Y-%m-%d)"
+```
+
+`layout.json` accepts any subset of `PdfLayoutOptions`:
+
+```json
+{
+  "pageSize": { "width": 595, "height": 842 },
+  "margin": { "top": 60, "right": 50, "bottom": 60, "left": 50 },
+  "compress": true,
+  "tagged": "pdfa2b",
+  "headerTemplate": { "left": "{title}", "right": "{date}" },
+  "footerTemplate": { "center": "Page {page} / {pages}" }
+}
+```
+
+> **Security:** `--layout` paths are validated against directory traversal, and any `attachments[].data` field embedded in the JSON is **stripped on load**. Binary attachment payloads must come from `--attachment <path>` so the CLI can apply the same path-validation rules.
 
 ---
 
@@ -122,16 +204,82 @@ JSON output (default) is suited for piping into `jq` or storing as a CI artifact
 
 ### `pdfnative render`
 
-Renders a JSON document into a PDF.
+Renders a JSON document into a PDF. Supports both renderer variants exposed by `pdfnative`.
+
+#### Core flags
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--input <file>` | stdin | Path to a JSON file containing [`DocumentParams`](https://pdfnative.dev/#api) |
+| `--input <file>` | stdin | JSON file ([`DocumentParams`](https://pdfnative.dev/#api) for `--variant document`, `PdfParams` for `--variant table`) |
 | `--output <file>` | stdout | Output PDF path |
-| `--stream` | off | Use streaming output (`AsyncGenerator<Uint8Array>`) — recommended for >100-page documents |
-| `--conformance <level>` | none | PDF/A conformance: `1b`, `2b`, `3b` |
+| `--variant document\|table` | `document` | Selects `buildDocumentPDFBytes` (free-form) or `buildPDFBytes` (table-centric) |
+| `--stream` | off | Streaming output via `streamDocumentPdf` (`AsyncGenerator<Uint8Array>`) — recommended for >100-page documents |
+| `--layout <file.json>` | — | Load any subset of `PdfLayoutOptions` |
 
-The JSON document accepts every public block type: `heading`, `paragraph`, `list`, `table`, `image`, `link`, `spacer`, `pageBreak`, `toc`, `barcode`, `svg`, `formField`. See the [Quick Start guide](quickstart.html) for full block schemas.
+#### Page geometry
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--page-size <name\|WxH>` | `a4` | Named (`a4`, `letter`, `legal`, `a3`, `tabloid`, `a5`) or `WxH` in points |
+| `--margin <N>` or `<t,r,b,l>` | `50` | Uniform or per-side margin in points |
+| `--compress` | off | Apply `/Filter /FlateDecode` to all content streams |
+
+#### PDF/A conformance
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--tagged <level>` | `none` | Unified PDF/A flag: `none`, `pdfa1b`, `pdfa2b`, `pdfa2u`, `pdfa3b` |
+| `--conformance <level>` | — | **Deprecated.** Maps to `--tagged pdfa<level>` with a one-line stderr notice. Removed in v1.0.0 |
+
+#### Watermarks
+
+| Flag | Description |
+|------|-------------|
+| `--watermark-text <str>` | Diagonal text watermark |
+| `--watermark-image <path>` | Image watermark (PNG/JPEG, centered, aspect-preserved) |
+| `--watermark-opacity <0..1>` | ExtGState `/ca` value |
+| `--watermark-angle <deg>` | Rotation angle |
+| `--watermark-color <hex\|R,G,B>` | Fill color (text only) |
+| `--watermark-font-size <pt>` | Font size (text only) |
+| `--watermark-position background\|foreground` | Drawing order vs. content |
+
+> Watermarks with transparency are **mutually exclusive** with PDF/A-1b (ISO 19005-1 §6.4). The CLI rejects this combination with exit 2.
+
+#### Headers / footers
+
+| Flag | Description |
+|------|-------------|
+| `--header-left <str>` / `--header-center` / `--header-right` | Page-template zones |
+| `--footer-left <str>` / `--footer-center` / `--footer-right` | Page-template zones |
+
+Supported placeholders: `{page}`, `{pages}`, `{date}`, `{title}`. The `{pages}` placeholder is rejected with `--stream` because the total page count is only known after multi-pass pagination.
+
+#### Encryption
+
+| Flag | Env var | Description |
+|------|---------|-------------|
+| `--encrypt-owner-pass <pass>` | `PDFNATIVE_ENCRYPT_OWNER_PASS` | **Required** if any `--encrypt-*` flag is set |
+| `--encrypt-user-pass <pass>` | `PDFNATIVE_ENCRYPT_USER_PASS` | Optional |
+| `--encrypt-algorithm <algo>` | — | `aes128` (default) or `aes256` |
+| `--encrypt-permissions <list>` | — | Comma list: `print`, `copy`, `modify`, `extractText` |
+
+Env vars take precedence over flags, ensuring secrets never appear in shell history. Encryption is **mutually exclusive** with `--tagged pdfa*` per ISO 19005-1 §6.3.2 — rejected with exit 2.
+
+#### PDF/A-3 attachments
+
+| Flag | Description |
+|------|-------------|
+| `--attachment <path>[:mime[:rel[:desc]]]` | Embed a file as `/EmbeddedFile`. Repeatable |
+
+The Windows drive-letter colon (`D:\path`) is detected and not split — see *Troubleshooting*.
+
+#### Multilingual fonts
+
+| Flag | Description |
+|------|-------------|
+| `--lang <code,code>` | Activate font loaders for the listed languages (e.g. `th,ja,ar`) |
+
+`--lang` activates a *programmatically registered* font loader via `loadFontData(code)`. Latin scripts are built-in; non-Latin scripts require the caller to invoke `registerFontLoader(lang, loader)` in a wrapper script before invoking the CLI. See *Recipes → Multilang via wrapper*.
 
 ### `pdfnative sign`
 
@@ -143,60 +291,133 @@ Applies a CMS/PKCS#7 digital signature to an existing PDF.
 | `--output <file>` | stdout | Output signed PDF |
 | `--key <file>` | `PDFNATIVE_SIGN_KEY` env | PEM-encoded private key (env var takes precedence) |
 | `--cert <file>` | `PDFNATIVE_SIGN_CERT` env | PEM-encoded X.509 certificate (env var takes precedence) |
+| `--cert-chain <file>` | `PDFNATIVE_SIGN_CHAIN` env | Intermediate-CA PEM (repeatable, concatenated into `certChain[]`) |
+| `--algorithm <algo>` | `rsa-sha256` | `rsa-sha256` or `ecdsa-sha256` (ECDSA returns a clear stub error in v0.2.0; full support tracked for v0.3.0) |
+| `--reason <str>` | — | `PdfSignOptions.reason` |
+| `--name <str>` | — | `PdfSignOptions.name` |
+| `--location <str>` | — | `PdfSignOptions.location` |
+| `--contact <str>` | — | `PdfSignOptions.contact` |
+| `--signing-time <ISO 8601>` | now | Explicit timestamp; validated up-front before any credential I/O |
 
 Signing keys are **never logged** — not in error output, not in debug traces, not in stack traces. The CLI redacts them at every code path that surfaces error context.
 
 ### `pdfnative inspect`
 
-Inspects metadata and conformance of an existing PDF.
+Inspects metadata and conformance of an existing PDF. Read-only — never modifies the input.
 
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--input <file>` | stdin | Input PDF |
-| `--format <fmt>` | `json` | Output format: `json` or `text` |
+| `--format <fmt>` | `json` | `json` or `text` |
+| `--verbose` | off | Adds `verbose.{trailerKeys, catalogKeys, objectCount, xmpMetadata}`. Sanitised — no raw stream bytes |
+| `--pages` | off | Adds `pages: [{ index, width, height, rotation, annotations, formFields }]` |
+| `--check <assertion>` | — | Repeatable; ANDed. Values: `pdfa`, `signed`, `encrypted`. Sets exit 0 = pass, 1 = fail |
 
-Inspection is **read-only** — the CLI never modifies the input PDF. The implementation uses `pdfnative`'s incremental parser (`src/parser/`), which means encrypted PDFs are reported but their content is not decrypted.
+Composable example:
+
+```bash
+pdfnative inspect --input dist/q1.pdf \
+  --check pdfa --check signed \
+  --format json > dist/q1.report.json
+echo "exit code: $?"   # 0 if both assertions hold
+```
+
+### `pdfnative verify` _(new in v0.2.0)_
+
+Verifies CMS/PKCS#7 signatures embedded in a PDF.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--input <file>` | stdin | Input PDF |
+| `--format <fmt>` | `json` | `json` or `text` |
+| `--strict` | off | Exit 1 on any failure or zero signatures |
+| `--trust <pem>` | — | Trust-anchor certificate (repeatable) |
+
+**Scope (v0.2.0):**
+
+- ✅ Byte-range integrity (SHA-256 recomputed and compared with CMS `messageDigest` attribute)
+- ✅ Certificate chain verification via `pdfnative`'s `verifyCertSignature`
+- ✅ Trust evaluation against `--trust` roots, with self-signed acceptance for testing
+
+**Out of scope (deferred):**
+
+- ⚠️ Full CMS signature-value verification — v0.3.0
+- ⚠️ OCSP / CRL revocation checks — v0.3.0+
+- ⚠️ RFC 3161 timestamp tokens — v0.3.0+
+- ⚠️ Long-Term Validation (LTV) — v0.3.0+
 
 ---
 
-## Composability — pipelines & batches
+## Recipes
 
-The CLI is designed to compose. Every command reads from stdin and writes to stdout when no `--input`/`--output` is given. This allows expressive shell pipelines:
-
-### Render → sign → inspect, in a single chain
+### Render → sign → verify → inspect, in a single chain
 
 ```bash
 cat report.json \
-  | pdfnative render \
-  | pdfnative sign \
-  | pdfnative inspect --format text
+  | pdfnative render --tagged pdfa2b --compress \
+  | pdfnative sign --reason "Approved" \
+  | tee signed.pdf \
+  | pdfnative verify --strict --trust ca.pem
+pdfnative inspect --input signed.pdf --check pdfa --check signed
 ```
 
-### Render to gzipped output
+### Encrypted PDF/A-3 hybrid invoice (Factur-X / ZUGFeRD)
 
 ```bash
-pdfnative render --input doc.json | gzip > report.pdf.gz
+pdfnative render \
+  --input invoice.json --output invoice.pdf \
+  --tagged pdfa3b \
+  --attachment factur-x.xml:application/xml:Source:"Structured invoice data" \
+  --footer-center "Page {page} / {pages}"
+```
+
+### Encrypted distribution copy
+
+```bash
+pdfnative render \
+  --input contract.json --output contract.encrypted.pdf \
+  --encrypt-algorithm aes256 \
+  --encrypt-permissions print
+# PDFNATIVE_ENCRYPT_OWNER_PASS read from the env — never on the command line
+```
+
+### Multilang via a wrapper script
+
+`pdfnative-cli` does not bundle non-Latin fonts. Register a font loader in a wrapper before delegating to the CLI:
+
+```javascript
+// wrapper.mjs
+import { registerFontLoader } from 'pdfnative';
+import { spawnSync } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+
+registerFontLoader('th', async () => JSON.parse(await readFile('./fonts/noto-thai-data.js', 'utf8')));
+registerFontLoader('ja', async () => JSON.parse(await readFile('./fonts/noto-jp-data.js', 'utf8')));
+
+spawnSync('npx', ['pdfnative-cli', ...process.argv.slice(2)], { stdio: 'inherit' });
+```
+
+```bash
+node wrapper.mjs render --input multilang.json --output out.pdf --lang th,ja
+```
+
+### CI assertion (GitHub Actions)
+
+```yaml
+- name: Render and assert PDF/A + signed
+  run: |
+    pdfnative render --input data/q1.json --output dist/q1.pdf --tagged pdfa2b
+    pdfnative sign  --input dist/q1.pdf  --output dist/q1.signed.pdf
+    pdfnative verify --input dist/q1.signed.pdf --strict
+    pdfnative inspect --input dist/q1.signed.pdf --check pdfa --check signed
 ```
 
 ### Batch-render a directory of JSON files
 
 ```bash
 for f in inputs/*.json; do
-  pdfnative render --input "$f" --output "outputs/$(basename "$f" .json).pdf"
+  pdfnative render --input "$f" --output "outputs/$(basename "$f" .json).pdf" --tagged pdfa2b
 done
-```
-
-### CI pipeline (GitHub Actions)
-
-```yaml
-- name: Render reports
-  run: |
-    pdfnative render --input data/q1.json --output dist/q1.pdf --conformance 2b
-    pdfnative inspect --input dist/q1.pdf --format json > dist/q1.metadata.json
-
-- name: Verify PDF/A
-  run: |
-    test "$(jq -r .pdfaConformance dist/q1.metadata.json)" = "2b"
 ```
 
 ---
@@ -206,8 +427,10 @@ done
 `pdfnative-cli` is built with the same zero-trust posture as the underlying library:
 
 - **No `eval`, no `Function`, no dynamic code** — input JSON is parsed via the standard `JSON.parse` with a 50 MB cap to prevent memory exhaustion.
-- **Path traversal protection** — all `--input` / `--output` / `--key` / `--cert` paths are validated against `..` segments before any file system access.
-- **Secrets never logged** — error messages and stack traces are redacted to remove key/cert contents at the boundary.
+- **Path traversal protection** — all `--input` / `--output` / `--key` / `--cert` / `--cert-chain` / `--trust` / `--layout` / `--attachment` / `--watermark-image` paths are validated against `..` segments before any file system access.
+- **Secrets never logged** — `loadPem` / `loadPemChain` surface only generic error messages on parse failure; raw key material never appears in `CliError` messages or stderr. Encryption passwords are never echoed.
+- **Layout-file injection blocked** — `attachments[].data` fields embedded in `--layout` JSON are **stripped on load**. Binary attachment payloads must come from `--attachment <path>` so the CLI can apply path validation.
+- **Env-var precedence for secrets** — `PDFNATIVE_SIGN_KEY` / `PDFNATIVE_SIGN_CERT` / `PDFNATIVE_SIGN_CHAIN` / `PDFNATIVE_ENCRYPT_OWNER_PASS` / `PDFNATIVE_ENCRYPT_USER_PASS` are preferred over file-path flags so secrets never enter shell history.
 - **Stdin/stdout safe** — binary streams are passed through without interpretation; no shell-quoting issues.
 - **NPM provenance** — every published version is signed via GitHub Actions OIDC. Verify with `npm audit signatures pdfnative-cli`.
 
@@ -217,43 +440,53 @@ The CLI **does not** open network connections, write to system directories outsi
 
 ## Comparison with the library API
 
-The CLI is a **strict subset** of the library's surface. Some advanced features remain library-only:
+The CLI now covers nearly the full library surface; only Web Worker offloading remains library-only.
 
-| Feature | CLI | Library |
+| Feature | CLI v0.2.0 | Library |
 |---|---|---|
 | Document rendering (12 block types) | ✅ | ✅ |
 | Streaming output | ✅ `--stream` | ✅ `streamDocumentPdf()` |
-| PDF/A conformance (1b, 2b, 3b) | ✅ `--conformance` | ✅ `tagged: '…'` |
-| Digital signatures (RSA, ECDSA) | ✅ | ✅ `signPdfBytes()` |
+| PDF/A conformance (1b, 2b, 2u, 3b) | ✅ `--tagged` | ✅ `tagged: '…'` |
+| Digital signatures (RSA) | ✅ | ✅ `signPdfBytes()` |
+| Digital signatures (ECDSA) | ⚠️ stub error in v0.2.0; v0.3.0 | ✅ `signPdfBytes()` |
 | Inspection / metadata | ✅ | ✅ `PdfReader` |
-| **Encryption (AES-128/256)** | ⚠️ library only | ✅ `encryption: {…}` |
-| **Watermarks** | ⚠️ library only | ✅ `watermark: {…}` |
-| **Custom page sizes** | ⚠️ library only | ✅ `pageSize: {…}` |
-| **Custom headers/footers** (templates) | ⚠️ library only | ✅ `headerTemplate` / `footerTemplate` |
+| **Signature verification** | ✅ `verify` (v0.2.0) | ✅ `verifyCertSignature` |
+| **Encryption (AES-128/256)** | ✅ `--encrypt-*` | ✅ `encryption: {…}` |
+| **Watermarks** | ✅ `--watermark-*` | ✅ `watermark: {…}` |
+| **Custom page sizes** | ✅ `--page-size` | ✅ `pageSize: {…}` |
+| **Custom headers/footers** | ✅ `--header-*` / `--footer-*` | ✅ `headerTemplate` / `footerTemplate` |
+| **PDF/A-3 attachments** | ✅ `--attachment` | ✅ `attachments: [...]` |
+| **Multilang fonts** | ✅ `--lang` (wrapper for non-Latin) | ✅ `registerFontLoader()` |
+| **Table-centric variant** | ✅ `--variant table` | ✅ `buildPDFBytes()` |
+| **Full `PdfLayoutOptions`** | ✅ `--layout file.json` | ✅ |
 | **Web Worker offloading** | ❌ N/A | ✅ `pdfWorker.ts` |
-
-Any feature with ⚠️ can be added to the CLI when there is concrete demand — open an issue at [Nizoka/pdfnative-cli/issues](https://github.com/Nizoka/pdfnative-cli/issues).
 
 ---
 
 ## Examples — ready-to-run
 
-The [`samples/`](https://github.com/Nizoka/pdfnative-cli/tree/main/samples) directory in the CLI repository ships **22 ready-to-run examples** organized by feature:
+The [`samples/`](https://github.com/Nizoka/pdfnative-cli/tree/main/samples) directory in the CLI repository ships **40+ ready-to-run examples** organized by feature:
 
-| Category | Files | What it shows |
-|---|---|---|
-| `render/document/` | 5 | Minimal document, all blocks reference, invoice, technical spec, multi-page report |
-| `render/table/` | 2 | Project status, financial summary |
-| `render/barcode/` | 3 | QR code, Code 128 shipping label, EAN-13 product |
-| `render/form/` | 2 | Contact form, survey |
-| `render/toc/` | 1 | Auto-generated table of contents with `/GoTo` links |
-| `render/link/` | 1 | Resource directory with hyperlinks |
-| `render/watermark/` | 2 | Draft / Confidential watermarks |
-| `render/layout/` | 3 | US Letter, A5 portrait, A4 landscape |
-| `render/pdfa/` | 3 | PDF/A-1b, 2b, 3b archival conformance |
-| `sign/` | 2 | Bash + PowerShell signing scripts |
-| `inspect/` | 4 | JSON & text inspection (Bash + PowerShell) |
-| `streaming/` | 1 | 200-section document via streaming render |
+| Category | What it shows |
+|---|---|
+| `render/document/` | Minimal document, all blocks reference, invoice, technical spec, multi-page report |
+| `render/table/` | Project status, financial summary |
+| `render/table-variant/` | `PdfParams`-shaped financial ledger via `--variant table` |
+| `render/barcode/` | QR code, Code 128, EAN-13 |
+| `render/form/` | Contact form, survey |
+| `render/toc/` | Auto-generated table of contents with `/GoTo` links |
+| `render/link/` | Resource directory with hyperlinks |
+| `render/watermark/` | Draft / Confidential watermarks |
+| `render/layout/` | US Letter, A5 portrait, A4 landscape |
+| `render/pdfa/` | PDF/A-1b, 2b, 3b archival conformance |
+| `render/encryption/` | AES-128 password-protected PDF |
+| `render/headers-footers/` | Page templates with `{page}/{pages}/{date}/{title}` |
+| `render/attachments/` | PDF/A-3 hybrid invoice with embedded XML (Factur-X / ZUGFeRD) |
+| `render/multilang/` | Latin-only registration guide; multilang scripts via wrapper |
+| `sign/` | Bash + PowerShell signing scripts (basic + with metadata) |
+| `inspect/` | JSON & text inspection, `--verbose --pages`, `--check pdfa` |
+| `verify/` | Self-signed verification, strict-mode CI gating |
+| `streaming/` | 200-section document via streaming render |
 
 Render them all at once:
 
@@ -265,22 +498,49 @@ node samples/run-all.js
 
 ---
 
+## Migration v0.1.0 → v0.2.0
+
+**100 % backward-compatible** — every v0.1.0 invocation continues to produce a byte-equivalent PDF, modulo a one-line stderr notice for `--conformance`. All v0.1.0 exit codes and JSON shapes are preserved; new `inspect` JSON fields are additive only.
+
+The only soft change you should plan for:
+
+```diff
+- pdfnative render --input doc.json --output report.pdf --conformance 2b
++ pdfnative render --input doc.json --output report.pdf --tagged pdfa2b
+```
+
+`--conformance` will be **removed in v1.0.0** of the CLI.
+
+---
+
 ## Troubleshooting
 
 ### `command not found: pdfnative`
 You installed via `npx` (one-shot) and not globally. Either prepend `npx` to every invocation, or run `npm install --global pdfnative-cli`.
 
 ### `JSON parse error: input too large`
-The CLI caps input JSON at 50 MB to prevent memory exhaustion. For very large documents, either split the document into multiple PDFs (then concat with `pdfnative-merge` — coming in v0.2) or use the library directly with the streaming API.
+The CLI caps input JSON at 50 MB to prevent memory exhaustion. For very large documents, either split the document into multiple PDFs or use the library directly with the streaming API.
 
 ### `Error: invalid private key`
-Both RSA PKCS#1 and ECDSA P-256 keys are accepted, but they must be **PEM-encoded**. Convert DER to PEM with `openssl pkcs8 -topk8 -in key.der -out key.pem -nocrypt`.
+Both RSA PKCS#1 and ECDSA P-256 keys are accepted, but they must be **PEM-encoded**. Convert DER to PEM with `openssl pkcs8 -topk8 -in key.der -out key.pem -nocrypt`. ECDSA support in `sign` returns a clear stub error in v0.2.0 — full support tracked for v0.3.0 once `pdfnative` exposes `parseEcPrivateKey`.
 
-### `Error: PDF/A conformance level 'X' is not supported`
-The CLI accepts `1b`, `2b`, `3b`. PDF/A-2u is library-only as of pdfnative 1.0.5 — open an issue at [Nizoka/pdfnative-cli](https://github.com/Nizoka/pdfnative-cli/issues) if you need it.
+### `Error: --encrypt-* flag set without --encrypt-owner-pass`
+Encryption requires an owner password. Provide it via `--encrypt-owner-pass <pass>` or — recommended — the `PDFNATIVE_ENCRYPT_OWNER_PASS` env var so it never enters shell history.
+
+### `Error: --tagged pdfa* and --encrypt-* are mutually exclusive`
+ISO 19005-1 §6.3.2 forbids encryption in PDF/A. Pick one — either an archival PDF/A document, or an encrypted distribution copy, but not both.
+
+### `ENOENT: no such file or directory, 'D\'`  (Windows)
+This was a v0.1.0 / pre-v0.2.0 regression: `--attachment D:\file.xml` was split at the drive-letter colon. Fixed in v0.2.0 — make sure you're on `pdfnative-cli@^0.2.0`.
+
+### Layout file is ignored when I also pass CLI flags
+That is the **intended precedence**: `CLI flags > --layout file > pdfnative defaults`. To merge nested objects (e.g. a watermark in the layout file plus a `--watermark-text` on the CLI), the CLI now correctly merges `params.layout` with CLI-derived flags as of v0.2.0 (previously the JSON-embedded layout could be silently dropped — fixed).
+
+### `--lang th` does not produce Thai glyphs
+`--lang` activates a *registered* font loader. The CLI process has an empty in-memory registry by default. Use a wrapper script that calls `registerFontLoader('th', loader)` before delegating to the CLI — see *Recipes → Multilang via a wrapper*.
 
 ### Signed PDF fails Adobe verification
-Ensure your certificate's signing-key usage extension includes `digitalSignature` (key usage 0). Self-signed certificates work for testing but require the validator to trust the issuer.
+Ensure your certificate's signing-key usage extension includes `digitalSignature` (key usage 0). Self-signed certificates work for testing but require the validator to trust the issuer — pass `--trust ca-root.pem` to `verify` for self-signed setups.
 
 ---
 
@@ -290,6 +550,7 @@ Ensure your certificate's signing-key usage extension includes `digitalSignature
 - 🏛️ **Repo:** [Nizoka/pdfnative-cli](https://github.com/Nizoka/pdfnative-cli)
 - 📚 **Knowledge base:** [pdfnative-cli/docs/KNOWLEDGE_BASE.md](https://github.com/Nizoka/pdfnative-cli/blob/main/docs/KNOWLEDGE_BASE.md) — full architecture, integration patterns, FAQ
 - 📁 **Samples:** [pdfnative-cli/samples](https://github.com/Nizoka/pdfnative-cli/tree/main/samples)
+- 🧪 **Try it interactively:** [CLI playground](../playgrounds/cli.html) — build commands without leaving the browser
 - 🔧 **Underlying library:** [`pdfnative`](https://github.com/Nizoka/pdfnative)
 - 🤖 **AI integration:** [pdfnative-mcp guide](mcp.html) — same library exposed as a Model Context Protocol server
 - 🐛 **Report a bug:** [Nizoka/pdfnative-cli/issues](https://github.com/Nizoka/pdfnative-cli/issues)

--- a/docs/guides/faq.html
+++ b/docs/guides/faq.html
@@ -24,7 +24,10 @@
       <li><a href="../#features">Features</a></li>
       <li><a href="../#examples">Examples</a></li>
       <li><a href="../#demo">Demo</a></li>
+      <li><a href="../#mcp">MCP</a></li>
+      <li><a href="../#cli">CLI</a></li>
       <li><a href="./">Guides</a></li>
+      <li><a href="../playgrounds/">Playgrounds</a></li>
       <li><a href="https://github.com/Nizoka/pdfnative" target="_blank" rel="noopener">GitHub</a></li>
       <li><button class="theme-toggle" aria-label="Toggle dark mode">🌙</button></li>
     </ul>

--- a/docs/guides/index.html
+++ b/docs/guides/index.html
@@ -23,7 +23,10 @@
       <li><a href="../#features">Features</a></li>
       <li><a href="../#examples">Examples</a></li>
       <li><a href="../#demo">Demo</a></li>
+      <li><a href="../#mcp">MCP</a></li>
+      <li><a href="../#cli">CLI</a></li>
       <li><a href="./" aria-current="page">Guides</a></li>
+      <li><a href="../playgrounds/">Playgrounds</a></li>
       <li><a href="https://github.com/Nizoka/pdfnative" target="_blank" rel="noopener">GitHub</a></li>
       <li><button class="theme-toggle" aria-label="Toggle dark mode">🌙</button></li>
     </ul>
@@ -83,6 +86,14 @@
 
     <h2>Interactive playgrounds</h2>
     <ul class="guide-toc-list">
+      <li>
+        <a href="../playgrounds/mcp.html">MCP tool explorer →</a>
+        <span class="guide-toc-desc">Browse the eight pdfnative-mcp tools, copy a ready-to-paste config snippet for Claude / Cursor / Continue / Zed, and generate the same PDFs an AI assistant would receive — all in your browser.</span>
+      </li>
+      <li>
+        <a href="../playgrounds/cli.html">CLI command builder →</a>
+        <span class="guide-toc-desc">Compose <code>pdfnative-cli</code> v0.2.0 commands (render / sign / inspect / verify) interactively. Live shell preview, validation, and one-click presets for every common workflow.</span>
+      </li>
       <li>
         <a href="../playgrounds/extreme-scripts.html">Extreme scripts playground →</a>
         <span class="guide-toc-desc">Stress-test BiDi (Arabic + Hebrew + Thai), Tamil deep conjuncts, Bengali &amp; Devanagari reph + ligature chains, and isolated Arabic harakat directly in the browser.</span>

--- a/docs/guides/mcp.html
+++ b/docs/guides/mcp.html
@@ -24,8 +24,10 @@
       <li><a href="../#features">Features</a></li>
       <li><a href="../#examples">Examples</a></li>
       <li><a href="../#demo">Demo</a></li>
-      <li><a href="../#mcp">MCP</a></li>
+      <li><a href="../#mcp" aria-current="page">MCP</a></li>
+      <li><a href="../#cli">CLI</a></li>
       <li><a href="./">Guides</a></li>
+      <li><a href="../playgrounds/">Playgrounds</a></li>
       <li><a href="https://github.com/Nizoka/pdfnative" target="_blank" rel="noopener">GitHub</a></li>
       <li><button class="theme-toggle" aria-label="Toggle dark mode">🌙</button></li>
     </ul>

--- a/docs/guides/pdfa.html
+++ b/docs/guides/pdfa.html
@@ -24,7 +24,10 @@
       <li><a href="../#features">Features</a></li>
       <li><a href="../#examples">Examples</a></li>
       <li><a href="../#demo">Demo</a></li>
+      <li><a href="../#mcp">MCP</a></li>
+      <li><a href="../#cli">CLI</a></li>
       <li><a href="./">Guides</a></li>
+      <li><a href="../playgrounds/">Playgrounds</a></li>
       <li><a href="https://github.com/Nizoka/pdfnative" target="_blank" rel="noopener">GitHub</a></li>
       <li><button class="theme-toggle" aria-label="Toggle dark mode">🌙</button></li>
     </ul>

--- a/docs/guides/quickstart.html
+++ b/docs/guides/quickstart.html
@@ -24,7 +24,10 @@
       <li><a href="../#features">Features</a></li>
       <li><a href="../#examples">Examples</a></li>
       <li><a href="../#demo">Demo</a></li>
+      <li><a href="../#mcp">MCP</a></li>
+      <li><a href="../#cli">CLI</a></li>
       <li><a href="./">Guides</a></li>
+      <li><a href="../playgrounds/">Playgrounds</a></li>
       <li><a href="https://github.com/Nizoka/pdfnative" target="_blank" rel="noopener">GitHub</a></li>
       <li><button class="theme-toggle" aria-label="Toggle dark mode">🌙</button></li>
     </ul>

--- a/docs/guides/troubleshooting.html
+++ b/docs/guides/troubleshooting.html
@@ -24,7 +24,10 @@
       <li><a href="../#features">Features</a></li>
       <li><a href="../#examples">Examples</a></li>
       <li><a href="../#demo">Demo</a></li>
+      <li><a href="../#mcp">MCP</a></li>
+      <li><a href="../#cli">CLI</a></li>
       <li><a href="./">Guides</a></li>
+      <li><a href="../playgrounds/">Playgrounds</a></li>
       <li><a href="https://github.com/Nizoka/pdfnative" target="_blank" rel="noopener">GitHub</a></li>
       <li><button class="theme-toggle" aria-label="Toggle dark mode">🌙</button></li>
     </ul>

--- a/docs/index.html
+++ b/docs/index.html
@@ -64,8 +64,9 @@
       <li><a href="#benchmarks">Benchmarks</a></li>
       <li><a href="#architecture">Architecture</a></li>
       <li><a href="#mcp">MCP</a></li>
+      <li><a href="#cli">CLI</a></li>
       <li><a href="guides/">Guides</a></li>
-      <li><a href="playgrounds/extreme-scripts.html">Playgrounds</a></li>
+      <li><a href="playgrounds/">Playgrounds</a></li>
       <li><a href="https://github.com/Nizoka/pdfnative" target="_blank" rel="noopener">GitHub</a></li>
       <li><button class="theme-toggle" aria-label="Toggle dark mode">🌙</button></li>
     </ul>
@@ -97,6 +98,7 @@
       <a href="https://www.typescriptlang.org/" target="_blank" rel="noopener"><img src="https://img.shields.io/badge/TypeScript-strict-blue" alt="TypeScript strict mode" height="20" loading="lazy"></a>
       <a href="https://docs.npmjs.com/generating-provenance-statements" target="_blank" rel="noopener"><img src="https://img.shields.io/badge/provenance-signed-blueviolet" alt="npm provenance signed" height="20" loading="lazy"></a>
       <a href="https://github.com/Nizoka/pdfnative/blob/main/LICENSE" target="_blank" rel="noopener"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="MIT License" height="20" loading="lazy"></a>
+      <a href="https://www.npmjs.com/package/pdfnative-cli" target="_blank" rel="noopener"><img src="https://img.shields.io/npm/v/pdfnative-cli?label=pdfnative-cli&color=0e7490" alt="pdfnative-cli npm version" height="20" loading="lazy"></a>
     </div>
     <div class="install-cmd">
       <code>npm install pdfnative</code>
@@ -181,13 +183,13 @@
       <div class="feature-card">
         <div class="feature-icon fi-mcp"><svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/><path d="M7 8h2M15 8h2M11 8h2"/></svg></div>
         <h3>AI Integration — MCP</h3>
-        <p>Use pdfnative from Claude Desktop, Cursor, Continue, and Zed via <a href="https://github.com/Nizoka/pdfnative-mcp" target="_blank" rel="noopener">pdfnative-mcp</a>. 8 production tools, zero configuration beyond <code>npx -y pdfnative-mcp</code>.</p>
+        <p>Use pdfnative from Claude Desktop, Cursor, Continue, Zed, and any other stdio MCP client (Cline, Windsurf, Goose, Gemini CLI…) via <a href="https://github.com/Nizoka/pdfnative-mcp" target="_blank" rel="noopener">pdfnative-mcp</a>. 8 production tools, zero configuration beyond <code>npx -y pdfnative-mcp</code>.</p>
       </div>
 
       <div class="feature-card">
         <div class="feature-icon fi-cli"><svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg></div>
         <h3>Command-Line Interface</h3>
-        <p>Render JSON to PDF, sign, and inspect from the terminal with <a href="https://github.com/Nizoka/pdfnative-cli" target="_blank" rel="noopener">pdfnative-cli</a>. Stdin/stdout pipelines, streaming, PDF/A. <a href="guides/cli.html">Read the CLI guide →</a></p>
+        <p>Render, sign, inspect &amp; <strong>verify</strong> PDFs from the terminal with <a href="https://github.com/Nizoka/pdfnative-cli" target="_blank" rel="noopener">pdfnative-cli</a> v0.2.0. Encryption, watermarks, headers/footers, PDF/A-3 attachments, multilingual fonts, signature metadata + cert chains. <a href="guides/cli.html">Read the CLI guide →</a> &middot; <a href="playgrounds/cli.html">Try the playground →</a></p>
       </div>
 
     </div>
@@ -546,7 +548,7 @@ const pdf = buildDocumentPDFBytes({
     <p class="section-subtitle">Strict unidirectional dependency flow. No circular imports. Each module is independently testable.</p>
     <div class="arch-diagram">
       <a href="https://github.com/Nizoka/pdfnative/tree/master/src" target="_blank" rel="noopener">
-        <img src="assets/architecture.svg" alt="pdfnative module architecture: pdfnative-mcp ecosystem consumer above the library, types → core ← fonts ← shaping ← worker, with standalone crypto and parser modules" width="960" height="540" loading="lazy">
+        <img src="assets/architecture.svg" alt="pdfnative module architecture: pdfnative-cli (4 commands: render · sign · inspect · verify) and pdfnative-mcp (8 tools, any stdio client) ecosystem consumers above the library, types → core ← fonts ← shaping (GSUB · GPOS · BiDi · 16 scripts) ← worker, with standalone crypto and parser modules" width="960" height="540" loading="lazy">
       </a>
     </div>
   </div>
@@ -584,7 +586,41 @@ const pdf = buildDocumentPDFBytes({
     }
   }
 }</code></pre>
-        <p>Supports Cursor, Continue, Zed, and any stdio MCP client. See the <a href="guides/mcp.html">MCP Integration Guide →</a></p>
+        <p>Supports Cursor, Continue, Zed, and any stdio MCP client. See the <a href="guides/mcp.html">MCP Integration Guide →</a> &middot; <a href="playgrounds/mcp.html">Try the MCP playground →</a></p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═══════════════ CLI ═══════════════ -->
+<section class="section" id="cli">
+  <div class="container">
+    <h2 class="section-title">Use pdfnative from your shell, CI, or Makefile</h2>
+    <p class="section-subtitle"><a href="https://github.com/Nizoka/pdfnative-cli" target="_blank" rel="noopener">pdfnative-cli</a> v0.2.0 is the <strong>official command-line interface</strong>. Four commands, zero extra runtime dependencies, stdin/stdout pipelines, NPM-provenance signed. Covers the full <code>pdfnative</code> v1.0.5 surface — encryption, watermarks, headers/footers, PDF/A-3 attachments, multilingual fonts, signing metadata, and signature verification.</p>
+    <div class="mcp-layout">
+      <div class="mcp-tools">
+        <h3>4 Production Commands</h3>
+        <table class="mcp-table">
+          <thead><tr><th>Command</th><th>Purpose</th></tr></thead>
+          <tbody>
+            <tr><td><code>render</code></td><td>JSON → PDF, hybrid <code>flags + --layout</code> model, encryption, watermarks, page templates, PDF/A-3 attachments, multilingual fonts, streaming</td></tr>
+            <tr><td><code>sign</code></td><td>CMS/PKCS#7 signatures (RSA today; ECDSA stub) with <code>--reason</code>/<code>--name</code>/<code>--location</code>/<code>--contact</code>/<code>--signing-time</code> and intermediate cert chains</td></tr>
+            <tr><td><code>inspect</code></td><td>Read-only PDF analysis. <code>--verbose</code>, <code>--pages</code>, and <code>--check pdfa|signed|encrypted</code> for CI assertions</td></tr>
+            <tr><td><code>verify</code> <span style="color:var(--c-success);font-size:11px;font-weight:700;">NEW v0.2.0</span></td><td>Verify CMS/PKCS#7 signatures: byte-range integrity, certificate chain, trust roots. <code>--strict</code> and <code>--trust</code> for CI</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="mcp-config">
+        <h3>One npx away</h3>
+<pre><code class="language-bash">npx pdfnative-cli render --input doc.json --output report.pdf \
+  --tagged pdfa2b --compress \
+  --watermark-text "DRAFT" --watermark-opacity 0.15
+
+npx pdfnative-cli sign --input report.pdf --output signed.pdf \
+  --reason "Approved" --signing-time 2026-04-28T10:00:00Z
+
+npx pdfnative-cli verify --input signed.pdf --strict</code></pre>
+        <p>Keys, certs, and encryption passwords are read from env vars (<code>PDFNATIVE_SIGN_KEY</code>, <code>PDFNATIVE_ENCRYPT_OWNER_PASS</code>…) and never logged. See the <a href="guides/cli.html">CLI guide →</a> &middot; <a href="playgrounds/cli.html">Try the CLI builder →</a></p>
       </div>
     </div>
   </div>
@@ -625,8 +661,11 @@ const pdf = buildDocumentPDFBytes({
       <li><a href="guides/accessibility.html">Accessibility</a></li>
       <li><a href="guides/pdfa.html">PDF/A</a></li>
       <li><a href="guides/mcp.html">MCP Integration</a></li>
+      <li><a href="guides/cli.html">CLI Guide</a></li>
       <li><a href="playgrounds/extreme-scripts.html">Extreme scripts playground</a></li>
       <li><a href="playgrounds/medical-800.html">Medical 800-page playground</a></li>
+      <li><a href="playgrounds/cli.html">CLI playground</a></li>
+      <li><a href="playgrounds/mcp.html">MCP playground</a></li>
       <li><a href="https://plika.app" target="_blank" rel="noopener">Originally from Plika.app</a></li>
     </ul>
   </div>

--- a/docs/playgrounds/cli.html
+++ b/docs/playgrounds/cli.html
@@ -1,0 +1,714 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CLI Command Builder — pdfnative-cli playground</title>
+  <meta name="description" content="Interactive command-builder for pdfnative-cli v0.2.0 — assemble render, sign, inspect, and verify invocations with full flag coverage. Live shell preview, copy-to-clipboard, validation. Zero install.">
+  <link rel="canonical" href="https://pdfnative.dev/playgrounds/cli.html">
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+  <link rel="stylesheet" href="../style.css">
+  <link rel="stylesheet" href="../guides/guide.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-tomorrow.min.css">
+  <style>
+    .cli-tabs { display: flex; gap: 4px; margin: 24px 0 0; border-bottom: 1px solid var(--c-border); flex-wrap: wrap; }
+    .cli-tab { padding: 10px 18px; background: transparent; border: none; border-bottom: 2px solid transparent; color: var(--c-text-dim); cursor: pointer; font-size: 14px; font-weight: 600; }
+    .cli-tab:hover { color: var(--c-text); }
+    .cli-tab[aria-selected="true"] { color: var(--c-primary); border-bottom-color: var(--c-primary); }
+    .cli-tab .new-badge { display: inline-block; margin-left: 6px; padding: 1px 6px; border-radius: 4px; background: var(--c-success); color: #fff; font-size: 10px; font-weight: 700; vertical-align: middle; }
+    .cli-form { display: grid; grid-template-columns: 1fr 1fr; gap: 14px 18px; margin-top: 24px; }
+    .cli-form .full { grid-column: 1 / -1; }
+    .cli-form label { display: block; font-size: 13px; font-weight: 600; color: var(--c-text); margin-bottom: 4px; }
+    .cli-form .hint { display: block; font-size: 12px; color: var(--c-text-dim); margin-top: 2px; line-height: 1.4; }
+    .cli-form input[type="text"],
+    .cli-form input[type="number"],
+    .cli-form select,
+    .cli-form textarea { width: 100%; padding: 8px 10px; border: 1px solid var(--c-border); border-radius: 6px; font-size: 13px; font-family: inherit; background: var(--c-bg); color: var(--c-text); }
+    .cli-form textarea { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; min-height: 70px; resize: vertical; }
+    .cli-form input[type="checkbox"] { margin-right: 6px; vertical-align: middle; }
+    .cli-form fieldset { grid-column: 1 / -1; border: 1px solid var(--c-border); border-radius: 8px; padding: 14px 16px 12px; margin: 8px 0 0; }
+    .cli-form legend { padding: 0 8px; font-size: 13px; font-weight: 700; color: var(--c-text); }
+    .cli-form fieldset > .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px 16px; }
+    .cli-preview { margin-top: 28px; }
+    .cli-preview h3 { font-size: 16px; font-weight: 700; margin-bottom: 10px; display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+    .cli-preview pre { background: var(--c-code-bg); color: var(--c-code-text); padding: 16px; border-radius: 8px; font-size: 13px; overflow-x: auto; line-height: 1.5; }
+    .cli-preview .copy-btn { padding: 4px 10px; font-size: 12px; background: var(--c-primary); color: #fff; border: none; border-radius: 4px; cursor: pointer; font-weight: 600; }
+    .cli-preview .copy-btn:hover { background: var(--c-accent); }
+    .cli-validation { margin-top: 14px; padding: 12px 14px; border-radius: 6px; font-size: 13px; line-height: 1.5; display: none; }
+    .cli-validation.error { display: block; background: #fee2e2; border: 1px solid #fca5a5; color: #991b1b; }
+    [data-theme="dark"] .cli-validation.error { background: #450a0a; border-color: #7f1d1d; color: #fecaca; }
+    .cli-validation.warn { display: block; background: #fef3c7; border: 1px solid #fcd34d; color: #78350f; }
+    [data-theme="dark"] .cli-validation.warn { background: #422006; border-color: #92400e; color: #fde68a; }
+    .cli-presets { display: flex; gap: 8px; align-items: center; margin: 18px 0 0; flex-wrap: wrap; }
+    .cli-presets select { padding: 6px 10px; border: 1px solid var(--c-border); border-radius: 6px; font-size: 13px; background: var(--c-bg); color: var(--c-text); }
+    .cli-panel { display: none; }
+    .cli-panel.active { display: block; }
+    @media (max-width: 768px) { .cli-form, .cli-form fieldset > .grid { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body>
+
+<nav class="nav" role="navigation" aria-label="Main navigation">
+  <div class="nav-inner">
+    <a class="nav-brand" href="../">
+      <img src="../assets/logo.svg" alt="" width="28" height="28">
+      pdfnative
+    </a>
+    <button class="nav-hamburger" aria-label="Toggle menu" aria-expanded="false">☰</button>
+    <ul class="nav-links" role="list">
+      <li><a href="../#features">Features</a></li>
+      <li><a href="../#examples">Examples</a></li>
+      <li><a href="../#demo">Demo</a></li>
+      <li><a href="../#mcp">MCP</a></li>
+      <li><a href="../#cli">CLI</a></li>
+      <li><a href="../guides/">Guides</a></li>
+      <li><a href="./">Playgrounds</a></li>
+      <li><a href="https://github.com/Nizoka/pdfnative" target="_blank" rel="noopener">GitHub</a></li>
+      <li><button class="theme-toggle" aria-label="Toggle dark mode">🌙</button></li>
+    </ul>
+  </div>
+</nav>
+
+<main class="guide-shell">
+  <p class="guide-breadcrumb"><a href="../">Home</a> &nbsp;›&nbsp; <a href="./">Playgrounds</a> &nbsp;›&nbsp; CLI command builder</p>
+  <nav class="playground-switcher" aria-label="Playground switcher">
+    <span class="playground-switcher-label">Playgrounds:</span>
+    <a href="./extreme-scripts.html">Extreme scripts</a>
+    <a href="./medical-800.html">Medical 800-page</a>
+    <a href="./cli.html" aria-current="page">CLI builder</a>
+    <a href="./mcp.html">MCP explorer</a>
+    <a href="./" style="margin-left:auto;">All →</a>
+  </nav>
+  <article class="guide-content">
+    <h1>pdfnative-cli command builder</h1>
+    <p>Pick a command, fill the form, copy the resulting <code>npx pdfnative-cli</code> invocation. Covers the full <a href="../guides/cli.html">v0.2.0 surface</a>: <code>render</code>, <code>sign</code>, <code>inspect</code>, and <code>verify</code>. The builder runs entirely in your browser — nothing is uploaded.</p>
+
+    <div class="cli-presets">
+      <label for="preset"><strong>Quick preset:</strong></label>
+      <select id="preset">
+        <option value="">— blank —</option>
+        <option value="render-basic">render · basic document</option>
+        <option value="render-pdfa">render · PDF/A-2b + compress</option>
+        <option value="render-watermark">render · watermarked draft</option>
+        <option value="render-encrypted">render · AES-256 encrypted</option>
+        <option value="render-headers">render · header / footer with placeholders</option>
+        <option value="render-attachment">render · PDF/A-3 with attachment</option>
+        <option value="render-table">render · table variant + layout file</option>
+        <option value="sign-meta">sign · with metadata + cert chain</option>
+        <option value="inspect-check">inspect · CI assertions</option>
+        <option value="verify-strict">verify · strict + trust roots</option>
+      </select>
+      <button id="reset" class="btn btn-secondary" style="padding: 6px 14px; font-size: 13px;">Reset</button>
+    </div>
+
+    <div class="cli-tabs" role="tablist">
+      <button class="cli-tab" role="tab" aria-selected="true"  data-tab="render">render</button>
+      <button class="cli-tab" role="tab" aria-selected="false" data-tab="sign">sign</button>
+      <button class="cli-tab" role="tab" aria-selected="false" data-tab="inspect">inspect</button>
+      <button class="cli-tab" role="tab" aria-selected="false" data-tab="verify">verify <span class="new-badge">v0.2.0</span></button>
+    </div>
+
+    <!-- ─────────────── RENDER ─────────────── -->
+    <section class="cli-panel active" data-panel="render">
+      <div class="cli-form">
+        <div>
+          <label for="r-input">--input</label>
+          <input id="r-input" type="text" data-cmd="render" data-flag="--input" placeholder="document.json">
+          <span class="hint">Path to JSON input. Omit to read from stdin.</span>
+        </div>
+        <div>
+          <label for="r-output">--output</label>
+          <input id="r-output" type="text" data-cmd="render" data-flag="--output" placeholder="report.pdf">
+          <span class="hint">Output path. Omit to write to stdout.</span>
+        </div>
+        <div>
+          <label for="r-variant">--variant</label>
+          <select id="r-variant" data-cmd="render" data-flag="--variant">
+            <option value="">document (default)</option>
+            <option value="document">document</option>
+            <option value="table">table</option>
+          </select>
+          <span class="hint">Selects the renderer variant.</span>
+        </div>
+        <div>
+          <label for="r-page-size">--page-size</label>
+          <select id="r-page-size" data-cmd="render" data-flag="--page-size">
+            <option value="">a4 (default)</option>
+            <option value="a4">a4</option>
+            <option value="letter">letter</option>
+            <option value="legal">legal</option>
+            <option value="a3">a3</option>
+            <option value="tabloid">tabloid</option>
+            <option value="a5">a5</option>
+            <option value="__custom__">custom WxH…</option>
+          </select>
+          <input id="r-page-size-custom" type="text" placeholder="595x842" style="margin-top: 6px; display: none;" data-cmd="render" data-flag="--page-size-custom">
+        </div>
+        <div>
+          <label for="r-margin">--margin</label>
+          <input id="r-margin" type="text" data-cmd="render" data-flag="--margin" placeholder="50  or  60,50,60,50">
+          <span class="hint">Single value or top,right,bottom,left in points.</span>
+        </div>
+        <div>
+          <label for="r-tagged">--tagged</label>
+          <select id="r-tagged" data-cmd="render" data-flag="--tagged">
+            <option value="">none (default)</option>
+            <option value="pdfa1b">pdfa1b</option>
+            <option value="pdfa2b">pdfa2b</option>
+            <option value="pdfa2u">pdfa2u</option>
+            <option value="pdfa3b">pdfa3b</option>
+          </select>
+        </div>
+        <div>
+          <label><input type="checkbox" data-cmd="render" data-flag="--compress"> --compress</label>
+          <span class="hint">FlateDecode all content streams.</span>
+        </div>
+        <div>
+          <label><input type="checkbox" data-cmd="render" data-flag="--stream"> --stream</label>
+          <span class="hint">AsyncGenerator streaming output.</span>
+        </div>
+        <div class="full">
+          <label for="r-layout">--layout (file path)</label>
+          <input id="r-layout" type="text" data-cmd="render" data-flag="--layout" placeholder="layout.json">
+          <span class="hint">Load any subset of <code>PdfLayoutOptions</code>. CLI flags override the layout file.</span>
+        </div>
+        <div class="full">
+          <label for="r-lang">--lang</label>
+          <input id="r-lang" type="text" data-cmd="render" data-flag="--lang" placeholder="th,ja,ar">
+          <span class="hint">Comma-separated language codes. Non-Latin requires a <code>registerFontLoader()</code> wrapper.</span>
+        </div>
+
+        <fieldset>
+          <legend>Watermark</legend>
+          <div class="grid">
+            <div>
+              <label for="r-wm-text">--watermark-text</label>
+              <input id="r-wm-text" type="text" data-cmd="render" data-flag="--watermark-text" placeholder="DRAFT">
+            </div>
+            <div>
+              <label for="r-wm-image">--watermark-image</label>
+              <input id="r-wm-image" type="text" data-cmd="render" data-flag="--watermark-image" placeholder="logo.png">
+            </div>
+            <div>
+              <label for="r-wm-opacity">--watermark-opacity</label>
+              <input id="r-wm-opacity" type="text" data-cmd="render" data-flag="--watermark-opacity" placeholder="0.15">
+            </div>
+            <div>
+              <label for="r-wm-angle">--watermark-angle</label>
+              <input id="r-wm-angle" type="text" data-cmd="render" data-flag="--watermark-angle" placeholder="-30">
+            </div>
+            <div>
+              <label for="r-wm-color">--watermark-color</label>
+              <input id="r-wm-color" type="text" data-cmd="render" data-flag="--watermark-color" placeholder="#cccccc">
+            </div>
+            <div>
+              <label for="r-wm-size">--watermark-font-size</label>
+              <input id="r-wm-size" type="text" data-cmd="render" data-flag="--watermark-font-size" placeholder="72">
+            </div>
+            <div>
+              <label for="r-wm-pos">--watermark-position</label>
+              <select id="r-wm-pos" data-cmd="render" data-flag="--watermark-position">
+                <option value="">background (default)</option>
+                <option value="background">background</option>
+                <option value="foreground">foreground</option>
+              </select>
+            </div>
+          </div>
+        </fieldset>
+
+        <fieldset>
+          <legend>Headers / footers</legend>
+          <div class="grid">
+            <div><label for="r-hl">--header-left</label><input id="r-hl" type="text" data-cmd="render" data-flag="--header-left" placeholder="{title}"></div>
+            <div><label for="r-hc">--header-center</label><input id="r-hc" type="text" data-cmd="render" data-flag="--header-center"></div>
+            <div><label for="r-hr">--header-right</label><input id="r-hr" type="text" data-cmd="render" data-flag="--header-right" placeholder="{date}"></div>
+            <div><label for="r-fl">--footer-left</label><input id="r-fl" type="text" data-cmd="render" data-flag="--footer-left"></div>
+            <div><label for="r-fc">--footer-center</label><input id="r-fc" type="text" data-cmd="render" data-flag="--footer-center" placeholder="Page {page} / {pages}"></div>
+            <div><label for="r-fr">--footer-right</label><input id="r-fr" type="text" data-cmd="render" data-flag="--footer-right"></div>
+          </div>
+          <span class="hint" style="margin-top: 8px; display: block;">Placeholders: <code>{page}</code>, <code>{pages}</code>, <code>{date}</code>, <code>{title}</code>. <code>{pages}</code> is rejected with <code>--stream</code>.</span>
+        </fieldset>
+
+        <fieldset>
+          <legend>Encryption (mutually exclusive with <code>--tagged pdfa*</code>)</legend>
+          <div class="grid">
+            <div>
+              <label for="r-enc-owner">--encrypt-owner-pass</label>
+              <input id="r-enc-owner" type="text" data-cmd="render" data-flag="--encrypt-owner-pass" placeholder="$PDFNATIVE_ENCRYPT_OWNER_PASS">
+              <span class="hint">Required if any <code>--encrypt-*</code> flag is set. Prefer the env var.</span>
+            </div>
+            <div>
+              <label for="r-enc-user">--encrypt-user-pass</label>
+              <input id="r-enc-user" type="text" data-cmd="render" data-flag="--encrypt-user-pass">
+            </div>
+            <div>
+              <label for="r-enc-algo">--encrypt-algorithm</label>
+              <select id="r-enc-algo" data-cmd="render" data-flag="--encrypt-algorithm">
+                <option value="">aes128 (default)</option>
+                <option value="aes128">aes128</option>
+                <option value="aes256">aes256</option>
+              </select>
+            </div>
+            <div>
+              <label for="r-enc-perm">--encrypt-permissions</label>
+              <input id="r-enc-perm" type="text" data-cmd="render" data-flag="--encrypt-permissions" placeholder="print,copy">
+            </div>
+          </div>
+        </fieldset>
+
+        <fieldset>
+          <legend>PDF/A-3 attachments</legend>
+          <div>
+            <label for="r-attach">--attachment (one per line)</label>
+            <textarea id="r-attach" data-cmd="render" data-flag="--attachment" placeholder="factur-x.xml:application/xml:Source:Structured invoice data"></textarea>
+            <span class="hint">Format: <code>path[:mime[:relationship[:description]]]</code>. Repeatable.</span>
+          </div>
+        </fieldset>
+      </div>
+    </section>
+
+    <!-- ─────────────── SIGN ─────────────── -->
+    <section class="cli-panel" data-panel="sign">
+      <div class="cli-form">
+        <div>
+          <label for="s-input">--input</label>
+          <input id="s-input" type="text" data-cmd="sign" data-flag="--input" placeholder="report.pdf">
+        </div>
+        <div>
+          <label for="s-output">--output</label>
+          <input id="s-output" type="text" data-cmd="sign" data-flag="--output" placeholder="signed.pdf">
+        </div>
+        <div>
+          <label for="s-key">--key</label>
+          <input id="s-key" type="text" data-cmd="sign" data-flag="--key" placeholder="key.pem">
+          <span class="hint">Or set <code>$PDFNATIVE_SIGN_KEY</code>.</span>
+        </div>
+        <div>
+          <label for="s-cert">--cert</label>
+          <input id="s-cert" type="text" data-cmd="sign" data-flag="--cert" placeholder="cert.pem">
+          <span class="hint">Or set <code>$PDFNATIVE_SIGN_CERT</code>.</span>
+        </div>
+        <div class="full">
+          <label for="s-chain">--cert-chain (one per line)</label>
+          <textarea id="s-chain" data-cmd="sign" data-flag="--cert-chain" placeholder="intermediate.pem"></textarea>
+          <span class="hint">Repeatable. Or set <code>$PDFNATIVE_SIGN_CHAIN</code>.</span>
+        </div>
+        <div>
+          <label for="s-algo">--algorithm</label>
+          <select id="s-algo" data-cmd="sign" data-flag="--algorithm">
+            <option value="">rsa-sha256 (default)</option>
+            <option value="rsa-sha256">rsa-sha256</option>
+            <option value="ecdsa-sha256">ecdsa-sha256 (stub in v0.2.0)</option>
+          </select>
+        </div>
+        <div>
+          <label for="s-time">--signing-time</label>
+          <input id="s-time" type="text" data-cmd="sign" data-flag="--signing-time" placeholder="2026-04-28T10:00:00Z">
+        </div>
+        <div>
+          <label for="s-reason">--reason</label>
+          <input id="s-reason" type="text" data-cmd="sign" data-flag="--reason" placeholder="Approved by Finance">
+        </div>
+        <div>
+          <label for="s-name">--name</label>
+          <input id="s-name" type="text" data-cmd="sign" data-flag="--name" placeholder="Finance Team">
+        </div>
+        <div>
+          <label for="s-loc">--location</label>
+          <input id="s-loc" type="text" data-cmd="sign" data-flag="--location" placeholder="Paris, FR">
+        </div>
+        <div>
+          <label for="s-contact">--contact</label>
+          <input id="s-contact" type="text" data-cmd="sign" data-flag="--contact" placeholder="finance@acme.example">
+        </div>
+      </div>
+    </section>
+
+    <!-- ─────────────── INSPECT ─────────────── -->
+    <section class="cli-panel" data-panel="inspect">
+      <div class="cli-form">
+        <div>
+          <label for="i-input">--input</label>
+          <input id="i-input" type="text" data-cmd="inspect" data-flag="--input" placeholder="signed.pdf">
+        </div>
+        <div>
+          <label for="i-format">--format</label>
+          <select id="i-format" data-cmd="inspect" data-flag="--format">
+            <option value="">json (default)</option>
+            <option value="json">json</option>
+            <option value="text">text</option>
+          </select>
+        </div>
+        <div>
+          <label><input type="checkbox" data-cmd="inspect" data-flag="--verbose"> --verbose</label>
+          <span class="hint">Adds trailerKeys, catalogKeys, objectCount, xmpMetadata.</span>
+        </div>
+        <div>
+          <label><input type="checkbox" data-cmd="inspect" data-flag="--pages"> --pages</label>
+          <span class="hint">Per-page geometry, annotations, form fields.</span>
+        </div>
+        <fieldset class="full">
+          <legend>--check (CI assertions, ANDed)</legend>
+          <div class="grid">
+            <div><label><input type="checkbox" data-cmd="inspect" data-flag="--check" data-value="pdfa"> --check pdfa</label></div>
+            <div><label><input type="checkbox" data-cmd="inspect" data-flag="--check" data-value="signed"> --check signed</label></div>
+            <div><label><input type="checkbox" data-cmd="inspect" data-flag="--check" data-value="encrypted"> --check encrypted</label></div>
+          </div>
+          <span class="hint" style="margin-top: 8px; display: block;">Exit code 0 on all-pass, 1 on any failure. Composable with <code>--format</code>.</span>
+        </fieldset>
+      </div>
+    </section>
+
+    <!-- ─────────────── VERIFY ─────────────── -->
+    <section class="cli-panel" data-panel="verify">
+      <div class="cli-form">
+        <div>
+          <label for="v-input">--input</label>
+          <input id="v-input" type="text" data-cmd="verify" data-flag="--input" placeholder="signed.pdf">
+        </div>
+        <div>
+          <label for="v-format">--format</label>
+          <select id="v-format" data-cmd="verify" data-flag="--format">
+            <option value="">json (default)</option>
+            <option value="json">json</option>
+            <option value="text">text</option>
+          </select>
+        </div>
+        <div>
+          <label><input type="checkbox" data-cmd="verify" data-flag="--strict"> --strict</label>
+          <span class="hint">Exit 1 on any failure or zero signatures.</span>
+        </div>
+        <div class="full">
+          <label for="v-trust">--trust (one per line)</label>
+          <textarea id="v-trust" data-cmd="verify" data-flag="--trust" placeholder="ca-root.pem"></textarea>
+          <span class="hint">Trust-anchor PEMs. Repeatable.</span>
+        </div>
+      </div>
+      <p class="hint" style="margin-top: 14px;">Scope (v0.2.0): byte-range integrity (SHA-256), certificate chain, trust evaluation. Out of scope: full CMS signature-value, OCSP/CRL, RFC 3161 timestamps, LTV — see the <a href="../guides/cli.html#pdfnative-verify-new-in-v020">CLI guide</a>.</p>
+    </section>
+
+    <div class="cli-validation" id="validation"></div>
+
+    <div class="cli-preview">
+      <h3>Generated command <button class="copy-btn" id="copy">Copy</button></h3>
+<pre><code class="language-bash" id="cmd-output">npx pdfnative-cli render</code></pre>
+      <p class="hint" style="margin-top: 10px;">Paste this in any shell. Secrets are never sent — the entire builder runs client-side.</p>
+    </div>
+
+    <h2 style="margin-top: 36px;">What this playground does <em>not</em> do</h2>
+    <p>It does not <strong>execute</strong> the CLI in your browser — signing real PDFs requires real private keys, and we will not pretend to. For an in-browser demo of <code>render</code> output, see the <a href="../#demo">homepage live demo</a>. To exercise the full CLI on your machine: <code>npx pdfnative-cli &lt;your built command&gt;</code>.</p>
+
+    <h2>Resources</h2>
+    <ul>
+      <li><a href="../guides/cli.html">CLI guide</a> — full v0.2.0 reference, security model, recipes</li>
+      <li><a href="https://github.com/Nizoka/pdfnative-cli">pdfnative-cli on GitHub</a></li>
+      <li><a href="https://github.com/Nizoka/pdfnative-cli/blob/main/release-notes/v0.2.0.md">v0.2.0 release notes</a></li>
+      <li><a href="../guides/mcp.html">MCP guide</a> &middot; <a href="./mcp.html">MCP playground</a></li>
+    </ul>
+  </article>
+</main>
+
+<footer class="footer">
+  <div class="footer-inner">
+    <span>MIT License · © 2026 Nizoka</span>
+    <ul class="footer-links" role="list">
+      <li><a href="../">Home</a></li>
+      <li><a href="../guides/">Guides</a></li>
+      <li><a href="../guides/cli.html">CLI guide</a></li>
+      <li><a href="./extreme-scripts.html">Extreme scripts playground</a></li>
+      <li><a href="./medical-800.html">Medical 800-page playground</a></li>
+      <li><a href="./mcp.html">MCP playground</a></li>
+      <li><a href="https://github.com/Nizoka/pdfnative-cli" target="_blank" rel="noopener">pdfnative-cli</a></li>
+    </ul>
+  </div>
+</footer>
+
+<script>
+(function () {
+  'use strict';
+
+  // ── State ──────────────────────────────────────────
+  // For each command, an object { flagName: value | array | bool }
+  const state = { render: {}, sign: {}, inspect: {}, verify: {} };
+  let activeCmd = 'render';
+
+  // Repeatable flags (one occurrence per item)
+  const REPEATABLE = new Set(['--cert-chain', '--attachment', '--trust', '--check']);
+
+  // ── DOM helpers ───────────────────────────────────
+  const $  = (id) => document.getElementById(id);
+  const $$ = (sel, root = document) => Array.from(root.querySelectorAll(sel));
+
+  // ── Tabs ──────────────────────────────────────────
+  $$('.cli-tab').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      activeCmd = btn.dataset.tab;
+      $$('.cli-tab').forEach((b) => b.setAttribute('aria-selected', String(b === btn)));
+      $$('.cli-panel').forEach((p) => p.classList.toggle('active', p.dataset.panel === activeCmd));
+      render();
+    });
+  });
+
+  // ── Custom page-size toggle ───────────────────────
+  const pageSizeSelect = $('r-page-size');
+  const pageSizeCustom = $('r-page-size-custom');
+  pageSizeSelect.addEventListener('change', () => {
+    pageSizeCustom.style.display = pageSizeSelect.value === '__custom__' ? 'block' : 'none';
+    if (pageSizeSelect.value !== '__custom__') {
+      pageSizeCustom.value = '';
+      delete state.render['--page-size-custom'];
+    }
+    render();
+  });
+
+  // ── Generic input bindings ────────────────────────
+  $$('[data-cmd][data-flag]').forEach((el) => {
+    const evt = (el.tagName === 'SELECT' || el.type === 'checkbox') ? 'change' : 'input';
+    el.addEventListener(evt, () => collect(el));
+  });
+
+  function collect(el) {
+    const cmd = el.dataset.cmd;
+    const flag = el.dataset.flag;
+    const bag = state[cmd];
+
+    if (el.type === 'checkbox') {
+      // For repeatable --check use data-value to add/remove from an array
+      if (flag === '--check') {
+        const v = el.dataset.value;
+        let arr = Array.isArray(bag[flag]) ? bag[flag].slice() : [];
+        if (el.checked) { if (!arr.includes(v)) arr.push(v); }
+        else            { arr = arr.filter((x) => x !== v); }
+        if (arr.length) bag[flag] = arr; else delete bag[flag];
+      } else {
+        if (el.checked) bag[flag] = true; else delete bag[flag];
+      }
+    } else if (el.tagName === 'TEXTAREA') {
+      const lines = el.value.split('\n').map((s) => s.trim()).filter(Boolean);
+      if (lines.length) bag[flag] = lines; else delete bag[flag];
+    } else {
+      const v = el.value.trim();
+      if (v) bag[flag] = v; else delete bag[flag];
+    }
+    render();
+  }
+
+  // ── Validation rules ──────────────────────────────
+  function validate() {
+    const errors = [];
+    const warns = [];
+
+    if (activeCmd === 'render') {
+      const r = state.render;
+      const tagged = r['--tagged'];
+      const hasEncrypt = Object.keys(r).some((k) => k.startsWith('--encrypt-'));
+      const taggedIsPdfA = tagged && /^pdfa/.test(tagged);
+
+      if (hasEncrypt && taggedIsPdfA) {
+        errors.push('Encryption (`--encrypt-*`) is mutually exclusive with `--tagged pdfa*` per ISO 19005-1 §6.3.2.');
+      }
+      if (hasEncrypt && !r['--encrypt-owner-pass']) {
+        warns.push('`--encrypt-*` flag set without `--encrypt-owner-pass`. The CLI will exit 2 unless `PDFNATIVE_ENCRYPT_OWNER_PASS` is exported.');
+      }
+      const usesPagesPlaceholder = ['--header-left', '--header-center', '--header-right', '--footer-left', '--footer-center', '--footer-right']
+        .some((f) => typeof r[f] === 'string' && r[f].includes('{pages}'));
+      if (r['--stream'] && usesPagesPlaceholder) {
+        errors.push('`{pages}` placeholder requires multi-pass pagination and is rejected with `--stream`.');
+      }
+      if (taggedIsPdfA === false || tagged === '') { /* no-op */ }
+      if ((tagged === 'pdfa1b') && (r['--watermark-text'] || r['--watermark-image']) && (r['--watermark-opacity'] || true)) {
+        // Transparency is mutually exclusive with PDF/A-1b. We can't inspect every alpha source, so warn.
+        if (r['--watermark-opacity']) {
+          warns.push('PDF/A-1b forbids transparency (ISO 19005-1 §6.4); a watermark with `--watermark-opacity` will be rejected.');
+        }
+      }
+      if (pageSizeSelect.value === '__custom__' && pageSizeCustom.value && !/^\d+x\d+$/i.test(pageSizeCustom.value.trim())) {
+        errors.push('Custom `--page-size` must be `WxH` in points, e.g. `595x842`.');
+      }
+    }
+
+    if (activeCmd === 'sign') {
+      const s = state.sign;
+      if (!s['--input']) warns.push('`sign` requires `--input` (no stdin sentinel for binary signing in v0.2.0 sample workflows).');
+      if (s['--algorithm'] === 'ecdsa-sha256') {
+        warns.push('`--algorithm ecdsa-sha256` is parsed but returns a clear stub error in v0.2.0 (full support tracked for v0.3.0).');
+      }
+      if (s['--signing-time'] && !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/.test(s['--signing-time'])) {
+        errors.push('`--signing-time` must be ISO 8601 (e.g. `2026-04-28T10:00:00Z`).');
+      }
+    }
+
+    return { errors, warns };
+  }
+
+  // ── Command rendering ─────────────────────────────
+  function shellEscape(v) {
+    if (v === true) return '';
+    if (typeof v !== 'string') v = String(v);
+    if (v === '') return "''";
+    if (/^[A-Za-z0-9_./:@,=+-]+$/.test(v)) return v;     // safe characters
+    return "'" + v.replace(/'/g, `'\\''`) + "'";
+  }
+
+  function buildCommand() {
+    const bag = state[activeCmd];
+    const parts = ['npx', 'pdfnative-cli', activeCmd];
+
+    // Special render: combine --page-size + --page-size-custom
+    if (activeCmd === 'render') {
+      if (pageSizeSelect.value === '__custom__' && pageSizeCustom.value) {
+        parts.push('--page-size', shellEscape(pageSizeCustom.value.trim()));
+      } else if (bag['--page-size']) {
+        parts.push('--page-size', shellEscape(bag['--page-size']));
+      }
+    }
+
+    Object.keys(bag).forEach((flag) => {
+      if (flag === '--page-size' || flag === '--page-size-custom') return; // handled above
+      const v = bag[flag];
+      if (v === true) {
+        parts.push(flag);
+      } else if (Array.isArray(v)) {
+        v.forEach((item) => { parts.push(flag, shellEscape(item)); });
+      } else {
+        parts.push(flag, shellEscape(v));
+      }
+    });
+
+    // Wrap onto multiple lines for readability if long
+    const single = parts.join(' ');
+    if (single.length <= 80) return single;
+    let out = parts.slice(0, 3).join(' ');
+    let line = '';
+    for (let i = 3; i < parts.length; i++) {
+      const tok = parts[i];
+      const isFlag = tok.startsWith('--');
+      if (isFlag && line.length > 0) { out += ' \\\n  ' + line.trim(); line = ''; }
+      line += tok + ' ';
+    }
+    if (line.trim()) out += ' \\\n  ' + line.trim();
+    return out;
+  }
+
+  function render() {
+    const cmd = buildCommand();
+    const out = $('cmd-output');
+    out.textContent = cmd;
+    if (window.Prism) window.Prism.highlightElement(out);
+
+    const { errors, warns } = validate();
+    const v = $('validation');
+    if (errors.length) {
+      v.className = 'cli-validation error';
+      v.innerHTML = '<strong>Validation errors:</strong><ul style="margin: 6px 0 0 18px;">' + errors.map((e) => '<li>' + e + '</li>').join('') + '</ul>';
+    } else if (warns.length) {
+      v.className = 'cli-validation warn';
+      v.innerHTML = '<strong>Heads up:</strong><ul style="margin: 6px 0 0 18px;">' + warns.map((w) => '<li>' + w + '</li>').join('') + '</ul>';
+    } else {
+      v.className = 'cli-validation';
+      v.innerHTML = '';
+    }
+  }
+
+  // ── Copy ──────────────────────────────────────────
+  $('copy').addEventListener('click', async () => {
+    try {
+      await navigator.clipboard.writeText($('cmd-output').textContent);
+      const btn = $('copy'); const old = btn.textContent;
+      btn.textContent = 'Copied!'; setTimeout(() => { btn.textContent = old; }, 1500);
+    } catch (e) {
+      alert('Clipboard write failed: ' + (e && e.message ? e.message : e));
+    }
+  });
+
+  // ── Reset ─────────────────────────────────────────
+  $('reset').addEventListener('click', () => {
+    state.render = {}; state.sign = {}; state.inspect = {}; state.verify = {};
+    $$('[data-cmd][data-flag]').forEach((el) => {
+      if (el.type === 'checkbox') el.checked = false;
+      else if (el.tagName === 'SELECT') el.value = '';
+      else el.value = '';
+    });
+    pageSizeCustom.style.display = 'none';
+    pageSizeCustom.value = '';
+    $('preset').value = '';
+    render();
+  });
+
+  // ── Presets ───────────────────────────────────────
+  const PRESETS = {
+    'render-basic':      { tab: 'render', fields: { 'r-input': 'document.json', 'r-output': 'report.pdf' } },
+    'render-pdfa':       { tab: 'render', fields: { 'r-input': 'doc.json', 'r-output': 'archive.pdf', 'r-tagged': 'pdfa2b' }, checks: ['--compress'] },
+    'render-watermark':  { tab: 'render', fields: { 'r-input': 'doc.json', 'r-output': 'draft.pdf', 'r-wm-text': 'DRAFT', 'r-wm-opacity': '0.15', 'r-wm-angle': '-30' } },
+    'render-encrypted':  { tab: 'render', fields: { 'r-input': 'contract.json', 'r-output': 'contract.encrypted.pdf', 'r-enc-algo': 'aes256', 'r-enc-perm': 'print' } },
+    'render-headers':    { tab: 'render', fields: { 'r-input': 'report.json', 'r-output': 'report.pdf', 'r-hl': '{title}', 'r-hr': '{date}', 'r-fc': 'Page {page} / {pages}' } },
+    'render-attachment': { tab: 'render', fields: { 'r-input': 'invoice.json', 'r-output': 'invoice.pdf', 'r-tagged': 'pdfa3b' }, textareas: { 'r-attach': 'factur-x.xml:application/xml:Source:Structured invoice data' } },
+    'render-table':      { tab: 'render', fields: { 'r-input': 'ledger.json', 'r-output': 'ledger.pdf', 'r-variant': 'table', 'r-layout': 'layout.json' } },
+    'sign-meta':         { tab: 'sign',   fields: { 's-input': 'report.pdf', 's-output': 'signed.pdf', 's-reason': 'Approved by Finance', 's-name': 'Finance Team', 's-loc': 'Paris, FR', 's-time': '2026-04-28T10:00:00Z' }, textareas: { 's-chain': 'intermediate.pem' } },
+    'inspect-check':     { tab: 'inspect', fields: { 'i-input': 'signed.pdf', 'i-format': 'json' }, checks: ['--verbose'], multiCheck: { '--check': ['pdfa', 'signed'] } },
+    'verify-strict':     { tab: 'verify',  fields: { 'v-input': 'signed.pdf' }, checks: ['--strict'], textareas: { 'v-trust': 'ca-root.pem' } },
+  };
+
+  $('preset').addEventListener('change', (e) => {
+    const key = e.target.value;
+    if (!key) return;
+    $('reset').click();
+    const p = PRESETS[key];
+    // Switch tab
+    const tabBtn = $$('.cli-tab').find((b) => b.dataset.tab === p.tab);
+    if (tabBtn) tabBtn.click();
+    // Apply text/select fields
+    Object.entries(p.fields || {}).forEach(([id, val]) => {
+      const el = $(id); if (!el) return;
+      el.value = val;
+      el.dispatchEvent(new Event(el.tagName === 'SELECT' ? 'change' : 'input'));
+    });
+    // Apply boolean checkboxes (data-flag-only, no data-value)
+    (p.checks || []).forEach((flag) => {
+      const cb = $$(`input[type="checkbox"][data-cmd="${p.tab}"][data-flag="${flag}"]:not([data-value])`)[0];
+      if (cb) { cb.checked = true; cb.dispatchEvent(new Event('change')); }
+    });
+    // Apply multi-value checkboxes (--check pdfa, --check signed, …)
+    Object.entries(p.multiCheck || {}).forEach(([flag, values]) => {
+      values.forEach((v) => {
+        const cb = $$(`input[type="checkbox"][data-cmd="${p.tab}"][data-flag="${flag}"][data-value="${v}"]`)[0];
+        if (cb) { cb.checked = true; cb.dispatchEvent(new Event('change')); }
+      });
+    });
+    // Apply textareas
+    Object.entries(p.textareas || {}).forEach(([id, val]) => {
+      const el = $(id); if (!el) return;
+      el.value = val;
+      el.dispatchEvent(new Event('input'));
+    });
+  });
+
+  // ── Theme toggle (parity with main site) ──────────
+  const themeBtn = document.querySelector('.theme-toggle');
+  if (themeBtn) {
+    const stored = localStorage.getItem('pdfnative-theme');
+    if (stored) document.documentElement.setAttribute('data-theme', stored);
+    themeBtn.addEventListener('click', () => {
+      const cur = document.documentElement.getAttribute('data-theme') === 'dark' ? '' : 'dark';
+      if (cur) document.documentElement.setAttribute('data-theme', cur);
+      else     document.documentElement.removeAttribute('data-theme');
+      localStorage.setItem('pdfnative-theme', cur);
+    });
+  }
+
+  // ── Mobile hamburger ──────────────────────────────
+  const hb = document.querySelector('.nav-hamburger');
+  if (hb) hb.addEventListener('click', () => {
+    const nav = document.querySelector('.nav-links');
+    if (nav) nav.classList.toggle('open');
+    hb.setAttribute('aria-expanded', String(nav && nav.classList.contains('open')));
+  });
+
+  render();
+})();
+</script>
+
+<script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/prism.min.js" defer></script>
+<script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-bash.min.js" defer></script>
+</body>
+</html>

--- a/docs/playgrounds/extreme-scripts.html
+++ b/docs/playgrounds/extreme-scripts.html
@@ -24,9 +24,10 @@
       <li><a href="../#features">Features</a></li>
       <li><a href="../#examples">Examples</a></li>
       <li><a href="../#demo">Demo</a></li>
-      <li><a href="./extreme-scripts.html" aria-current="page">Extreme</a></li>
-      <li><a href="./medical-800.html">Medical 800p</a></li>
+      <li><a href="../#mcp">MCP</a></li>
+      <li><a href="../#cli">CLI</a></li>
       <li><a href="../guides/">Guides</a></li>
+      <li><a href="./">Playgrounds</a></li>
       <li><a href="https://github.com/Nizoka/pdfnative" target="_blank" rel="noopener">GitHub</a></li>
       <li><button class="theme-toggle" aria-label="Toggle dark mode">🌙</button></li>
     </ul>
@@ -34,7 +35,15 @@
 </nav>
 
 <main class="guide-shell">
-  <p class="guide-breadcrumb"><a href="../">Home</a> &nbsp;›&nbsp; Playgrounds &nbsp;›&nbsp; Extreme scripts</p>
+  <p class="guide-breadcrumb"><a href="../">Home</a> &nbsp;›&nbsp; <a href="./">Playgrounds</a> &nbsp;›&nbsp; Extreme scripts</p>
+  <nav class="playground-switcher" aria-label="Playground switcher">
+    <span class="playground-switcher-label">Playgrounds:</span>
+    <a href="./extreme-scripts.html" aria-current="page">Extreme scripts</a>
+    <a href="./medical-800.html">Medical 800-page</a>
+    <a href="./cli.html">CLI builder</a>
+    <a href="./mcp.html">MCP explorer</a>
+    <a href="./" style="margin-left:auto;">All →</a>
+  </nav>
   <article class="guide-content">
     <h1>Extreme Scripts Playground</h1>
     <p>Stress-test the pdfnative shaping pipeline against the most demanding inputs: deep BiDi mixing across 3+ scripts, Tamil ultra-conjuncts, Bengali &amp; Devanagari with reph + multi-halant ligature chains, and isolated Arabic harakat. Pick a preset, edit the text, and click <strong>Generate PDF</strong>.</p>

--- a/docs/playgrounds/index.html
+++ b/docs/playgrounds/index.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Playgrounds — pdfnative</title>
+  <meta name="description" content="Four interactive playgrounds for pdfnative: extreme-script shaping (BiDi, Tamil, Bengali, Devanagari), an 800-page Web Worker stress test, a CLI command builder, and a Model Context Protocol tool explorer. All zero-install, zero-config, in your browser.">
+  <link rel="canonical" href="https://pdfnative.dev/playgrounds/">
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+  <link rel="stylesheet" href="../style.css">
+  <link rel="stylesheet" href="../guides/guide.css">
+  <style>
+    .pg-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 20px; margin-top: 28px; }
+    .pg-card {
+      display: flex; flex-direction: column; gap: 10px;
+      padding: 22px 24px; border: 1px solid var(--c-border); border-radius: 12px;
+      background: var(--c-bg-card); text-decoration: none; color: inherit;
+      transition: border-color 0.15s, transform 0.15s, box-shadow 0.15s;
+    }
+    .pg-card:hover { border-color: var(--c-primary); transform: translateY(-2px); box-shadow: 0 6px 18px -8px rgba(37,99,235,0.35); }
+    .pg-card .pg-icon { font-size: 28px; line-height: 1; }
+    .pg-card h3 { font-size: 18px; margin: 0; color: var(--c-text); display: flex; align-items: center; gap: 10px; }
+    .pg-card h3 .badge { font-size: 11px; padding: 2px 7px; border-radius: 4px; background: var(--c-primary); color: #fff; font-weight: 700; letter-spacing: 0.04em; }
+    .pg-card h3 .badge.alt { background: #16a34a; }
+    .pg-card p { font-size: 14px; color: var(--c-text-dim); line-height: 1.55; margin: 0; }
+    .pg-card .pg-tags { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 4px; }
+    .pg-card .pg-tag { font-size: 11px; padding: 2px 8px; border-radius: 999px; background: var(--c-surface); color: var(--c-text-dim); font-weight: 600; }
+    .pg-card .pg-cta { font-size: 13px; font-weight: 600; color: var(--c-primary); margin-top: auto; padding-top: 4px; }
+  </style>
+</head>
+<body>
+
+<nav class="nav" role="navigation" aria-label="Main navigation">
+  <div class="nav-inner">
+    <a class="nav-brand" href="../">
+      <img src="../assets/logo.svg" alt="" width="28" height="28">
+      pdfnative
+    </a>
+    <button class="nav-hamburger" aria-label="Toggle menu" aria-expanded="false">☰</button>
+    <ul class="nav-links" role="list">
+      <li><a href="../#features">Features</a></li>
+      <li><a href="../#examples">Examples</a></li>
+      <li><a href="../#demo">Demo</a></li>
+      <li><a href="../#mcp">MCP</a></li>
+      <li><a href="../#cli">CLI</a></li>
+      <li><a href="../guides/">Guides</a></li>
+      <li><a href="./" aria-current="page">Playgrounds</a></li>
+      <li><a href="https://github.com/Nizoka/pdfnative" target="_blank" rel="noopener">GitHub</a></li>
+      <li><button class="theme-toggle" aria-label="Toggle dark mode">🌙</button></li>
+    </ul>
+  </div>
+</nav>
+
+<main class="guide-shell">
+  <p class="guide-breadcrumb"><a href="../">Home</a> &nbsp;›&nbsp; Playgrounds</p>
+  <article class="guide-content">
+    <h1>Interactive playgrounds</h1>
+    <p>Four hands-on environments that exercise the entire pdfnative ecosystem in your browser. No install, no API keys, no build step. Pick a card to dive in — every playground includes a switcher at the top so you can hop between them without coming back here.</p>
+
+    <div class="pg-grid">
+      <a class="pg-card" href="./extreme-scripts.html">
+        <div class="pg-icon" aria-hidden="true">🌍</div>
+        <h3>Extreme scripts <span class="badge">Library</span></h3>
+        <p>Stress-test BiDi mixing across Arabic + Hebrew + Thai + Latin, Tamil ultra-conjuncts, Bengali &amp; Devanagari with reph and multi-halant ligature chains, and isolated Arabic harakat. Edit the inputs and regenerate.</p>
+        <div class="pg-tags">
+          <span class="pg-tag">BiDi</span><span class="pg-tag">GSUB</span><span class="pg-tag">GPOS</span><span class="pg-tag">16 scripts</span>
+        </div>
+        <div class="pg-cta">Open extreme-scripts playground →</div>
+      </a>
+
+      <a class="pg-card" href="./medical-800.html">
+        <div class="pg-icon" aria-hidden="true">📊</div>
+        <h3>Medical 800-page <span class="badge">Library</span></h3>
+        <p>Generate a synthetic 800-page clinical report off the main thread using a Web Worker. Live progress bar, streaming output, optional Tagged PDF/A. The performance benchmark you can run yourself.</p>
+        <div class="pg-tags">
+          <span class="pg-tag">Web Worker</span><span class="pg-tag">Streaming</span><span class="pg-tag">Tagged PDF</span><span class="pg-tag">Benchmark</span>
+        </div>
+        <div class="pg-cta">Open medical-800 playground →</div>
+      </a>
+
+      <a class="pg-card" href="./cli.html">
+        <div class="pg-icon" aria-hidden="true">⌨️</div>
+        <h3>CLI builder <span class="badge alt">v0.2.0</span></h3>
+        <p>Compose <code>pdfnative-cli</code> commands (<code>render</code> · <code>sign</code> · <code>inspect</code> · <code>verify</code>) interactively. Live shell preview, validation rules, copy-to-clipboard, and 10 ready presets covering every common workflow.</p>
+        <div class="pg-tags">
+          <span class="pg-tag">render</span><span class="pg-tag">sign</span><span class="pg-tag">inspect</span><span class="pg-tag">verify</span>
+        </div>
+        <div class="pg-cta">Open CLI playground →</div>
+      </a>
+
+      <a class="pg-card" href="./mcp.html">
+        <div class="pg-icon" aria-hidden="true">🤖</div>
+        <h3>MCP tool explorer <span class="badge alt">v0.1.0</span></h3>
+        <p>Browse the eight <strong>pdfnative-mcp</strong> tools, copy a ready-to-paste config snippet for Claude Desktop, Cursor, Continue, Zed (or any stdio MCP client), and generate the same PDFs an AI assistant would receive — directly in your browser.</p>
+        <div class="pg-tags">
+          <span class="pg-tag">8 tools</span><span class="pg-tag">Claude</span><span class="pg-tag">Cursor</span><span class="pg-tag">Zed</span><span class="pg-tag">+ any stdio client</span>
+        </div>
+        <div class="pg-cta">Open MCP playground →</div>
+      </a>
+    </div>
+
+    <h2 style="margin-top: 44px;">What about non-interactive examples?</h2>
+    <p>The repository ships with <a href="https://github.com/Nizoka/pdfnative/tree/main/scripts/generators" target="_blank" rel="noopener">23 generator categories producing ~140 sample PDFs</a> covering financial statements, multi-language documents, barcodes, SVG, watermarks, forms, encryption, signatures, streaming, parser, and stress tests. Run <code>npm run test:generate</code> after cloning.</p>
+
+    <h2>Resources</h2>
+    <ul>
+      <li><a href="../guides/">All guides</a> — quick start, architecture, accessibility, PDF/A, troubleshooting, FAQ, MCP, CLI</li>
+      <li><a href="../#demo">Homepage live demo</a> — minimal in-page example</li>
+      <li><a href="https://github.com/Nizoka/pdfnative" target="_blank" rel="noopener">GitHub repository</a></li>
+    </ul>
+  </article>
+</main>
+
+<footer class="footer">
+  <div class="footer-inner">
+    <span>MIT License · © 2026 Nizoka</span>
+    <ul class="footer-links" role="list">
+      <li><a href="../">Home</a></li>
+      <li><a href="../guides/">Guides</a></li>
+      <li><a href="./extreme-scripts.html">Extreme scripts</a></li>
+      <li><a href="./medical-800.html">Medical 800-page</a></li>
+      <li><a href="./cli.html">CLI builder</a></li>
+      <li><a href="./mcp.html">MCP explorer</a></li>
+      <li><a href="https://github.com/Nizoka/pdfnative" target="_blank" rel="noopener">GitHub</a></li>
+    </ul>
+  </div>
+</footer>
+
+<script>
+  // Theme toggle parity
+  const themeBtn = document.querySelector('.theme-toggle');
+  if (themeBtn) {
+    const stored = localStorage.getItem('pdfnative-theme');
+    if (stored) document.documentElement.setAttribute('data-theme', stored);
+    themeBtn.addEventListener('click', () => {
+      const cur = document.documentElement.getAttribute('data-theme') === 'dark' ? '' : 'dark';
+      if (cur) document.documentElement.setAttribute('data-theme', cur);
+      else     document.documentElement.removeAttribute('data-theme');
+      localStorage.setItem('pdfnative-theme', cur);
+    });
+  }
+  const hb = document.querySelector('.nav-hamburger');
+  if (hb) hb.addEventListener('click', () => {
+    const nav = document.querySelector('.nav-links');
+    if (nav) nav.classList.toggle('open');
+    hb.setAttribute('aria-expanded', String(nav && nav.classList.contains('open')));
+  });
+</script>
+
+</body>
+</html>

--- a/docs/playgrounds/mcp.html
+++ b/docs/playgrounds/mcp.html
@@ -1,0 +1,468 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>MCP Tool Explorer — pdfnative-mcp playground</title>
+  <meta name="description" content="Interactive explorer for the 8 pdfnative-mcp tools. Browse the JSON schemas, see real example prompts, and generate the same PDFs an AI assistant would receive — directly in your browser. Zero install, zero secrets.">
+  <link rel="canonical" href="https://pdfnative.dev/playgrounds/mcp.html">
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+  <link rel="stylesheet" href="../style.css">
+  <link rel="stylesheet" href="../guides/guide.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-tomorrow.min.css">
+  <style>
+    .mcp-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(360px, 1fr)); gap: 18px; margin-top: 24px; }
+    .mcp-card { border: 1px solid var(--c-border); border-radius: 10px; padding: 18px 20px 16px; background: var(--c-bg-card); display: flex; flex-direction: column; gap: 10px; }
+    .mcp-card h3 { font-size: 16px; font-weight: 700; margin: 0; color: var(--c-text); display: flex; align-items: center; gap: 8px; }
+    .mcp-card h3 code { background: var(--c-surface); padding: 2px 8px; border-radius: 4px; font-size: 13px; color: var(--c-primary); }
+    .mcp-card .purpose { font-size: 13px; color: var(--c-text-dim); line-height: 1.5; margin: 0; }
+    .mcp-card details { font-size: 13px; }
+    .mcp-card details summary { cursor: pointer; font-weight: 600; color: var(--c-text); padding: 4px 0; }
+    .mcp-card details > div { margin-top: 8px; }
+    .mcp-card .prompt { background: var(--c-surface); border-left: 3px solid var(--c-primary); padding: 10px 12px; border-radius: 4px; font-size: 13px; line-height: 1.5; font-style: italic; }
+    .mcp-card pre { background: var(--c-code-bg); color: var(--c-code-text); padding: 12px; border-radius: 6px; font-size: 12px; overflow-x: auto; line-height: 1.45; max-height: 200px; }
+    .mcp-card .actions { display: flex; gap: 8px; margin-top: 4px; flex-wrap: wrap; }
+    .mcp-card button { padding: 6px 12px; font-size: 12px; border-radius: 4px; border: none; cursor: pointer; font-weight: 600; }
+    .mcp-card button.primary { background: var(--c-primary); color: #fff; }
+    .mcp-card button.primary:hover { background: var(--c-accent); }
+    .mcp-card button.secondary { background: var(--c-surface); color: var(--c-text); border: 1px solid var(--c-border); }
+    .mcp-card button.secondary:hover { background: var(--c-bg-alt); }
+    .mcp-card button:disabled { opacity: 0.5; cursor: not-allowed; }
+    .mcp-card .status { font-size: 12px; color: var(--c-text-dim); padding: 4px 0; min-height: 18px; }
+    .mcp-card .status.success { color: var(--c-success); font-weight: 600; }
+    .mcp-card .status.error { color: #b91c1c; font-weight: 600; }
+    [data-theme="dark"] .mcp-card .status.error { color: #fca5a5; }
+    .mcp-config-block { margin: 30px 0; padding: 20px 24px; border: 1px solid var(--c-border); border-radius: 10px; background: var(--c-bg-card); }
+    .mcp-config-block h2 { margin-top: 0; }
+    .mcp-config-tabs { display: flex; gap: 4px; margin-bottom: 12px; flex-wrap: wrap; border-bottom: 1px solid var(--c-border); }
+    .mcp-config-tabs button { padding: 8px 14px; background: transparent; border: none; border-bottom: 2px solid transparent; cursor: pointer; font-size: 13px; font-weight: 600; color: var(--c-text-dim); }
+    .mcp-config-tabs button[aria-selected="true"] { color: var(--c-primary); border-bottom-color: var(--c-primary); }
+    .mcp-config-block pre { position: relative; }
+    .mcp-config-block .copy-btn { position: absolute; top: 8px; right: 8px; padding: 4px 10px; font-size: 12px; background: var(--c-primary); color: #fff; border: none; border-radius: 4px; cursor: pointer; font-weight: 600; }
+  </style>
+</head>
+<body>
+
+<nav class="nav" role="navigation" aria-label="Main navigation">
+  <div class="nav-inner">
+    <a class="nav-brand" href="../">
+      <img src="../assets/logo.svg" alt="" width="28" height="28">
+      pdfnative
+    </a>
+    <button class="nav-hamburger" aria-label="Toggle menu" aria-expanded="false">☰</button>
+    <ul class="nav-links" role="list">
+      <li><a href="../#features">Features</a></li>
+      <li><a href="../#examples">Examples</a></li>
+      <li><a href="../#demo">Demo</a></li>
+      <li><a href="../#mcp">MCP</a></li>
+      <li><a href="../#cli">CLI</a></li>
+      <li><a href="../guides/">Guides</a></li>
+      <li><a href="./">Playgrounds</a></li>
+      <li><a href="https://github.com/Nizoka/pdfnative" target="_blank" rel="noopener">GitHub</a></li>
+      <li><button class="theme-toggle" aria-label="Toggle dark mode">🌙</button></li>
+    </ul>
+  </div>
+</nav>
+
+<main class="guide-shell">
+  <p class="guide-breadcrumb"><a href="../">Home</a> &nbsp;›&nbsp; <a href="./">Playgrounds</a> &nbsp;›&nbsp; MCP tool explorer</p>
+  <nav class="playground-switcher" aria-label="Playground switcher">
+    <span class="playground-switcher-label">Playgrounds:</span>
+    <a href="./extreme-scripts.html">Extreme scripts</a>
+    <a href="./medical-800.html">Medical 800-page</a>
+    <a href="./cli.html">CLI builder</a>
+    <a href="./mcp.html" aria-current="page">MCP explorer</a>
+    <a href="./" style="margin-left:auto;">All →</a>
+  </nav>
+  <article class="guide-content">
+    <h1>pdfnative-mcp tool explorer</h1>
+    <p>The eight tools an AI assistant gets when you wire <a href="https://github.com/Nizoka/pdfnative-mcp">pdfnative-mcp</a> (currently <strong>v0.1.0</strong>) into Claude Desktop, Cursor, Continue, Zed, or any other stdio MCP client (Cline, Windsurf, Goose, Gemini CLI…). Each card below shows a real example prompt, the tool-call payload your client emits, and a <strong>Generate PDF</strong> button that produces the very PDF the AI assistant would receive — running the underlying <a href="https://www.npmjs.com/package/pdfnative">pdfnative</a> library directly in your browser. No API keys, no install, no LLM cost.</p>
+
+    <p style="font-size: 14px; color: var(--c-text-dim);">For the full integration story (config, security model, signed-document workflow), see the <a href="../guides/mcp.html">MCP guide</a>.</p>
+
+    <div class="mcp-config-block">
+      <h2 style="font-size: 18px; margin-bottom: 8px;">1. Configure your client</h2>
+      <p style="font-size: 14px; color: var(--c-text-dim);">Pick your client. The snippet below is what you paste into its MCP servers config. <code>npx</code> downloads pdfnative-mcp on first use; no global install needed.</p>
+      <div class="mcp-config-tabs" role="tablist">
+        <button role="tab" aria-selected="true"  data-client="claude">Claude Desktop</button>
+        <button role="tab" aria-selected="false" data-client="cursor">Cursor</button>
+        <button role="tab" aria-selected="false" data-client="continue">Continue</button>
+        <button role="tab" aria-selected="false" data-client="zed">Zed</button>
+      </div>
+<pre><code class="language-json" id="config-output"></code><button class="copy-btn" id="copy-config">Copy</button></pre>
+      <p style="font-size: 13px; color: var(--c-text-dim); margin-top: 10px;"><strong>Other clients:</strong> any tool that speaks the <a href="https://modelcontextprotocol.io" target="_blank" rel="noopener">Model Context Protocol</a> over stdio works — Cline, Windsurf, Goose, Aider, LibreChat, Sourcegraph Cody, Gemini CLI, and your own custom client. Use the same <code>command: "npx"</code> / <code>args: ["-y", "pdfnative-mcp"]</code> pair in whatever JSON shape your client expects.</p>
+    </div>
+
+    <h2 style="margin-top: 36px;">2. Try the 8 tools</h2>
+    <p id="loader-status" style="font-size: 13px; color: var(--c-text-dim);">Loading <code>pdfnative</code> from esm.sh… this happens once per page load.</p>
+
+    <div class="mcp-cards" id="cards"></div>
+
+    <h2 style="margin-top: 40px;">3. Now ask your AI assistant</h2>
+    <p>Once you've pasted the config snippet above and restarted your client, ask it anything PDF-shaped:</p>
+    <ul>
+      <li><em>"Generate a 3-page invoice for ACME Corp totalling €1 200 and embed a QR code that links to the payment portal."</em></li>
+      <li><em>"Create a Thai-language welcome letter with our logo as a header."</em></li>
+      <li><em>"Draft a contract with a signature placeholder and inspect the resulting PDF for me."</em></li>
+    </ul>
+    <p>The AI assistant will pick the right tools, fill the JSON arguments, and pdfnative will render the PDF — no code from you.</p>
+
+    <h2>Resources</h2>
+    <ul>
+      <li><a href="../guides/mcp.html">MCP guide</a> — full configuration, security model, signed-document workflow</li>
+      <li><a href="https://github.com/Nizoka/pdfnative-mcp">pdfnative-mcp on GitHub</a></li>
+      <li><a href="../guides/cli.html">CLI guide</a> &middot; <a href="./cli.html">CLI playground</a></li>
+      <li><a href="https://modelcontextprotocol.io">Model Context Protocol specification</a></li>
+    </ul>
+  </article>
+</main>
+
+<footer class="footer">
+  <div class="footer-inner">
+    <span>MIT License · © 2026 Nizoka</span>
+    <ul class="footer-links" role="list">
+      <li><a href="../">Home</a></li>
+      <li><a href="../guides/">Guides</a></li>
+      <li><a href="../guides/mcp.html">MCP guide</a></li>
+      <li><a href="./extreme-scripts.html">Extreme scripts playground</a></li>
+      <li><a href="./medical-800.html">Medical 800-page playground</a></li>
+      <li><a href="./cli.html">CLI playground</a></li>
+      <li><a href="https://github.com/Nizoka/pdfnative-mcp" target="_blank" rel="noopener">pdfnative-mcp</a></li>
+    </ul>
+  </div>
+</footer>
+
+<script type="module">
+  // ─────────────────────────── Client config snippets ───────────────────────────
+  const CONFIGS = {
+    claude:   `{
+  "mcpServers": {
+    "pdfnative": {
+      "command": "npx",
+      "args": ["-y", "pdfnative-mcp"]
+    }
+  }
+}`,
+    cursor:   `// .cursor/mcp.json
+{
+  "mcpServers": {
+    "pdfnative": {
+      "command": "npx",
+      "args": ["-y", "pdfnative-mcp"]
+    }
+  }
+}`,
+    continue: `// ~/.continue/config.json — under "experimental.modelContextProtocolServers"
+{
+  "name": "pdfnative",
+  "transport": {
+    "type": "stdio",
+    "command": "npx",
+    "args": ["-y", "pdfnative-mcp"]
+  }
+}`,
+    zed:      `// ~/.config/zed/settings.json — under "context_servers"
+"context_servers": {
+  "pdfnative": {
+    "command": "npx",
+    "args": ["-y", "pdfnative-mcp"]
+  }
+}`,
+  };
+
+  const cfgOut = document.getElementById('config-output');
+  function setConfig(client) {
+    cfgOut.textContent = CONFIGS[client] || '';
+    if (window.Prism) window.Prism.highlightElement(cfgOut);
+  }
+  document.querySelectorAll('.mcp-config-tabs button').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      document.querySelectorAll('.mcp-config-tabs button').forEach((b) => b.setAttribute('aria-selected', String(b === btn)));
+      setConfig(btn.dataset.client);
+    });
+  });
+  setConfig('claude');
+
+  document.getElementById('copy-config').addEventListener('click', async () => {
+    try {
+      await navigator.clipboard.writeText(cfgOut.textContent);
+      const b = document.getElementById('copy-config'); const old = b.textContent;
+      b.textContent = 'Copied!'; setTimeout(() => { b.textContent = old; }, 1500);
+    } catch (e) { alert('Clipboard write failed.'); }
+  });
+
+  // ─────────────────────────── Tool catalogue ───────────────────────────
+  // Each tool maps to a real pdfnative entry-point so the playground can produce the
+  // PDF the AI assistant would receive. The `args` is the canonical MCP tool-call
+  // payload; `build(p, m)` returns Uint8Array bytes given those args + loaded module.
+  const TOOLS = [
+    {
+      id: 'generate_basic_pdf',
+      purpose: 'Render a multi-page document from headings, paragraphs, and lists.',
+      prompt: 'Write a one-page welcome memo titled "Welcome to ACME" with a paragraph and a bullet list of three onboarding steps.',
+      args: {
+        title: 'Welcome to ACME',
+        blocks: [
+          { type: 'heading', text: 'Welcome to ACME', level: 1 },
+          { type: 'paragraph', text: 'We are thrilled to have you on board. Here is what to expect during your first week.' },
+          { type: 'list', style: 'bullet', items: [
+            'Day 1 — meet your team and complete IT setup.',
+            'Day 2 — onboarding deep-dive with the People team.',
+            'Day 3 — shadow a customer call and review our product roadmap.',
+          ]},
+        ],
+        footerText: 'Confidential · ACME People Team',
+        metadata: { author: 'People Team', subject: 'Welcome' },
+      },
+      build: (p, m) => m.buildDocumentPDFBytes(p),
+    },
+    {
+      id: 'add_table',
+      purpose: 'Render a tabular report from headers and rows.',
+      prompt: 'Build a PDF with our Q1 vs Q2 revenue and profit table.',
+      args: {
+        title: 'H1 Performance',
+        blocks: [
+          { type: 'heading', text: 'H1 2026 — Performance', level: 1 },
+          { type: 'table',
+            headers: ['Quarter', 'Revenue', 'Profit'],
+            rows: [
+              { cells: ['Q1', '$1.2M', '$400K'], type: 'credit', pointed: false },
+              { cells: ['Q2', '$1.5M', '$600K'], type: 'credit', pointed: true  },
+            ],
+          },
+        ],
+      },
+      build: (p, m) => m.buildDocumentPDFBytes(p),
+    },
+    {
+      id: 'add_barcode',
+      purpose: 'Embed a QR code, Code 128, EAN-13, Data Matrix, or PDF417 barcode.',
+      prompt: 'Make a PDF that contains a QR code linking to our payment portal at https://acme.example/pay/INV-001.',
+      args: {
+        title: 'Invoice INV-001',
+        blocks: [
+          { type: 'heading', text: 'Invoice INV-001', level: 1 },
+          { type: 'paragraph', text: 'Scan the QR code below to settle this invoice.' },
+          { type: 'barcode', format: 'qr', data: 'https://acme.example/pay/INV-001', width: 140, ecLevel: 'M', align: 'center' },
+        ],
+      },
+      build: (p, m) => m.buildDocumentPDFBytes(p),
+    },
+    {
+      id: 'add_international_text',
+      purpose: 'Render text in any of 16 scripts with BiDi & OpenType shaping (Arabic, Thai, Japanese, …).',
+      prompt: 'Create a multilingual greeting card with English, Thai, and Arabic.',
+      args: {
+        title: 'Multilingual greeting',
+        fonts: [{ lang: 'th' }, { lang: 'ar' }],
+        blocks: [
+          { type: 'heading', text: 'Hello · สวัสดี · مرحبا', level: 1 },
+          { type: 'paragraph', text: 'English: a multilingual document rendered with native shaping and BiDi.' },
+          { type: 'paragraph', text: 'ภาษาไทย: เอกสารหลายภาษาที่จัดรูปแบบด้วยการสร้างรูปร่างและการจัดวางทิศทางสองทิศทาง' },
+          { type: 'paragraph', text: 'العربية: مستند متعدد اللغات يتم عرضه باستخدام التشكيل الأصلي ودعم اتجاهي ثنائي.' },
+        ],
+      },
+      build: async (p, m) => {
+        // Lazy-load Thai + Arabic font data the same way the homepage demo does.
+        const [thai, arabic] = await Promise.all([
+          import('https://esm.sh/pdfnative/fonts/noto-thai-data.js'),
+          import('https://esm.sh/pdfnative/fonts/noto-arabic-data.js'),
+        ]);
+        if (typeof m.registerFontLoader === 'function') {
+          m.registerFontLoader('th', () => Promise.resolve(thai.default || thai));
+          m.registerFontLoader('ar', () => Promise.resolve(arabic.default || arabic));
+        }
+        return m.buildDocumentPDFBytes(p);
+      },
+    },
+    {
+      id: 'add_form',
+      purpose: 'Build an interactive AcroForm PDF (text, checkbox, radio, dropdown).',
+      prompt: 'Create a contact form PDF with a name field, an email field, and a “subscribe to newsletter” checkbox.',
+      args: {
+        title: 'Contact us',
+        blocks: [
+          { type: 'heading', text: 'Contact us', level: 1 },
+          { type: 'formField', fieldType: 'text',     name: 'fullName', label: 'Full name', x: 60, y: 680, width: 300, height: 24 },
+          { type: 'formField', fieldType: 'text',     name: 'email',    label: 'Email',     x: 60, y: 640, width: 300, height: 24 },
+          { type: 'formField', fieldType: 'checkbox', name: 'subscribe', label: 'Subscribe to newsletter', x: 60, y: 600, width: 18, height: 18, checked: false },
+        ],
+      },
+      build: (p, m) => m.buildDocumentPDFBytes(p),
+    },
+    {
+      id: 'embed_image',
+      purpose: 'Embed a JPEG or PNG image (base64 encoded).',
+      prompt: 'Generate a PDF with our company logo as the first block.',
+      args: { /* placeholder: in this playground we draw a simple SVG-as-PDF since base64 image data can be very large */ },
+      noteHtml: 'In a real MCP call the AI assistant supplies the image as base64. The playground equivalent below uses an inline <code>svg</code> block so the demo stays small.',
+      build: (p, m) => m.buildDocumentPDFBytes({
+        title: 'Logo demo',
+        blocks: [
+          { type: 'svg', width: 80, height: 80, align: 'left', content:
+            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><rect x="3" y="2" width="14" height="18" rx="2" fill="#2563eb"/><path d="M7 7h6M7 11h8M7 15h4" stroke="white" stroke-width="1.6" stroke-linecap="round"/></svg>'
+          },
+          { type: 'heading', text: 'ACME Inc.', level: 1 },
+          { type: 'paragraph', text: 'Pure native PDF generation.' },
+        ],
+      }),
+    },
+    {
+      id: 'prepare_signature_placeholder',
+      purpose: 'Build a PDF with a /Sig signature field ready to be signed.',
+      prompt: 'Prepare a sign-ready contract PDF for the legal team.',
+      args: {
+        title: 'Service agreement (draft)',
+        blocks: [
+          { type: 'heading', text: 'Service agreement', level: 1 },
+          { type: 'paragraph', text: 'This agreement enters into effect upon countersignature by both parties.' },
+          { type: 'formField', fieldType: 'text', name: 'sigPlaceholder', label: 'Signature: ____________________', x: 60, y: 200, width: 300, height: 30 },
+        ],
+      },
+      build: (p, m) => m.buildDocumentPDFBytes(p),
+    },
+    {
+      id: 'sign_pdf',
+      purpose: 'Apply a CMS/PKCS#7 signature (RSA or ECDSA) to an existing PDF.',
+      prompt: 'Sign the prepared contract using our corporate certificate.',
+      args: {
+        algorithm: 'rsa-sha256',
+        reason: 'Approved by Legal',
+        name: 'Legal Department',
+        location: 'Paris, FR',
+        signingTime: '2026-04-28T10:00:00Z',
+      },
+      noteHtml: 'Signing requires real private keys we cannot ship in a public playground. The button below renders the unsigned source PDF this tool would receive; run <code>pdfnative-cli sign</code> locally with your real keys to apply the signature.',
+      build: (p, m) => m.buildDocumentPDFBytes({
+        title: 'Service agreement (unsigned)',
+        blocks: [
+          { type: 'heading', text: 'Service agreement', level: 1 },
+          { type: 'paragraph', text: 'Source document handed to sign_pdf — the MCP server would run signPdfBytes() with your private key and certificate.' },
+        ],
+      }),
+    },
+  ];
+
+  // ─────────────────────────── Card rendering ───────────────────────────
+  const cards = document.getElementById('cards');
+  TOOLS.forEach((t, idx) => {
+    const card = document.createElement('div');
+    card.className = 'mcp-card';
+    card.innerHTML = `
+      <h3><code>${t.id}</code></h3>
+      <p class="purpose">${t.purpose}</p>
+      <div class="prompt">${t.prompt}</div>
+      ${t.noteHtml ? `<p class="purpose">${t.noteHtml}</p>` : ''}
+      <details>
+        <summary>MCP tool-call payload</summary>
+        <div><pre><code class="language-json">${escapeHtml(JSON.stringify(t.args, null, 2))}</code></pre></div>
+      </details>
+      <div class="actions">
+        <button class="primary" data-action="run" data-tool="${idx}" disabled>Generate PDF</button>
+        <button class="secondary" data-action="copy-args" data-tool="${idx}">Copy args</button>
+      </div>
+      <div class="status" data-status></div>
+    `;
+    cards.appendChild(card);
+  });
+
+  function escapeHtml(s) {
+    return s.replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
+  }
+
+  // ─────────────────────────── pdfnative loader (mirrors app.js) ───────────────────────────
+  const CDN_URLS = ['https://esm.sh/pdfnative', 'https://unpkg.com/pdfnative?module'];
+  let pdfnativeMod = null;
+  let loadErr = null;
+
+  (async () => {
+    for (const url of CDN_URLS) {
+      try {
+        const mod = await import(url);
+        // esm.sh sometimes nests named exports under `.default`
+        pdfnativeMod = mod.buildDocumentPDFBytes ? mod : (mod.default && mod.default.buildDocumentPDFBytes ? mod.default : mod);
+        if (pdfnativeMod && typeof pdfnativeMod.buildDocumentPDFBytes === 'function') break;
+      } catch (e) { loadErr = e; }
+    }
+    const status = document.getElementById('loader-status');
+    if (pdfnativeMod && typeof pdfnativeMod.buildDocumentPDFBytes === 'function') {
+      status.textContent = 'pdfnative loaded — try any tool below.';
+      status.style.color = 'var(--c-success)';
+      document.querySelectorAll('button[data-action="run"]').forEach((b) => { b.disabled = false; });
+    } else {
+      status.textContent = 'Failed to load pdfnative from CDN: ' + (loadErr && loadErr.message ? loadErr.message : 'unknown error');
+      status.style.color = '#b91c1c';
+    }
+  })();
+
+  // ─────────────────────────── Actions ───────────────────────────
+  cards.addEventListener('click', async (ev) => {
+    const btn = ev.target.closest('button[data-action]');
+    if (!btn) return;
+    const card = btn.closest('.mcp-card');
+    const status = card.querySelector('[data-status]');
+    const tool = TOOLS[Number(btn.dataset.tool)];
+
+    if (btn.dataset.action === 'copy-args') {
+      try {
+        await navigator.clipboard.writeText(JSON.stringify(tool.args, null, 2));
+        status.textContent = 'Tool arguments copied.';
+        status.className = 'status success';
+        setTimeout(() => { status.textContent = ''; status.className = 'status'; }, 1800);
+      } catch (e) { status.textContent = 'Clipboard write failed.'; status.className = 'status error'; }
+      return;
+    }
+
+    if (btn.dataset.action === 'run') {
+      if (!pdfnativeMod) return;
+      btn.disabled = true;
+      status.textContent = 'Generating…'; status.className = 'status';
+      try {
+        const t0 = performance.now();
+        const bytes = await tool.build(tool.args, pdfnativeMod);
+        const elapsed = (performance.now() - t0).toFixed(0);
+        downloadPdf(bytes, tool.id + '.pdf');
+        status.textContent = `Generated ${(bytes.length / 1024).toFixed(1)} KB in ${elapsed} ms.`;
+        status.className = 'status success';
+      } catch (e) {
+        status.textContent = 'Error: ' + (e && e.message ? e.message : e);
+        status.className = 'status error';
+        console.error(e);
+      } finally { btn.disabled = false; }
+    }
+  });
+
+  function downloadPdf(bytes, name) {
+    const blob = new Blob([bytes], { type: 'application/pdf' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url; a.download = name;
+    document.body.appendChild(a); a.click();
+    setTimeout(() => { URL.revokeObjectURL(url); a.remove(); }, 1000);
+  }
+
+  // ─────────────────────────── Theme + hamburger parity ───────────────────────────
+  const themeBtn = document.querySelector('.theme-toggle');
+  if (themeBtn) {
+    const stored = localStorage.getItem('pdfnative-theme');
+    if (stored) document.documentElement.setAttribute('data-theme', stored);
+    themeBtn.addEventListener('click', () => {
+      const cur = document.documentElement.getAttribute('data-theme') === 'dark' ? '' : 'dark';
+      if (cur) document.documentElement.setAttribute('data-theme', cur);
+      else     document.documentElement.removeAttribute('data-theme');
+      localStorage.setItem('pdfnative-theme', cur);
+    });
+  }
+  const hb = document.querySelector('.nav-hamburger');
+  if (hb) hb.addEventListener('click', () => {
+    const nav = document.querySelector('.nav-links');
+    if (nav) nav.classList.toggle('open');
+    hb.setAttribute('aria-expanded', String(nav && nav.classList.contains('open')));
+  });
+</script>
+
+<script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/prism.min.js" defer></script>
+<script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-json.min.js" defer></script>
+</body>
+</html>

--- a/docs/playgrounds/medical-800.html
+++ b/docs/playgrounds/medical-800.html
@@ -23,9 +23,10 @@
       <li><a href="../#features">Features</a></li>
       <li><a href="../#examples">Examples</a></li>
       <li><a href="../#demo">Demo</a></li>
-      <li><a href="./extreme-scripts.html">Extreme</a></li>
-      <li><a href="./medical-800.html" aria-current="page">Medical 800p</a></li>
+      <li><a href="../#mcp">MCP</a></li>
+      <li><a href="../#cli">CLI</a></li>
       <li><a href="../guides/">Guides</a></li>
+      <li><a href="./">Playgrounds</a></li>
       <li><a href="https://github.com/Nizoka/pdfnative" target="_blank" rel="noopener">GitHub</a></li>
       <li><button class="theme-toggle" aria-label="Toggle dark mode">🌙</button></li>
     </ul>
@@ -33,7 +34,15 @@
 </nav>
 
 <main class="guide-shell">
-  <p class="guide-breadcrumb"><a href="../">Home</a> &nbsp;›&nbsp; Playgrounds &nbsp;›&nbsp; Medical 800-page</p>
+  <p class="guide-breadcrumb"><a href="../">Home</a> &nbsp;›&nbsp; <a href="./">Playgrounds</a> &nbsp;›&nbsp; Medical 800-page</p>
+  <nav class="playground-switcher" aria-label="Playground switcher">
+    <span class="playground-switcher-label">Playgrounds:</span>
+    <a href="./extreme-scripts.html">Extreme scripts</a>
+    <a href="./medical-800.html" aria-current="page">Medical 800-page</a>
+    <a href="./cli.html">CLI builder</a>
+    <a href="./mcp.html">MCP explorer</a>
+    <a href="./" style="margin-left:auto;">All →</a>
+  </nav>
   <article class="guide-content">
     <h1>800-page Medical Report — Web Worker Showcase</h1>
     <p>Generates a fictitious, fully synthetic medical report (anonymized data, deterministic seeded RNG) demonstrating how pdfnative scales to large documents off the main thread. Pages contain headers, footers, patient summaries, longitudinal vital signs tables, and laboratory results — typical real-world clinical document patterns.</p>

--- a/docs/style.css
+++ b/docs/style.css
@@ -471,3 +471,20 @@ img, svg { max-width: 100%; height: auto; }
   padding: 0; margin: -1px; overflow: hidden;
   clip: rect(0,0,0,0); border: 0;
 }
+
+/* ── Playground switcher (sub-nav between sibling playgrounds) ── */
+.playground-switcher {
+  display: flex; gap: 6px; flex-wrap: wrap; align-items: center;
+  padding: 10px 14px; margin: 14px 0 28px;
+  background: var(--c-bg-alt); border: 1px solid var(--c-border); border-radius: 8px;
+  font-size: 14px;
+}
+.playground-switcher-label { font-weight: 600; color: var(--c-text-dim); margin-right: 6px; }
+.playground-switcher a {
+  padding: 5px 12px; border-radius: 5px;
+  color: var(--c-text); text-decoration: none; font-weight: 500;
+  transition: background 0.15s, color 0.15s;
+}
+.playground-switcher a:hover { background: var(--c-surface); }
+.playground-switcher a[aria-current="page"] { background: var(--c-primary); color: #fff; }
+.playground-switcher a[aria-current="page"]:hover { background: var(--c-accent); }


### PR DESCRIPTION
## Description

Align pdfnative's public documentation site (`/docs`), README, and architecture diagram with the [pdfnative-cli v0.2.0](https://github.com/Nizoka/pdfnative-cli) release. This is a **docs-only release** with no library code changes, no version bump, and no CHANGELOG entry.

### Changes

**Homepage & Navigation**
- Add CLI as a first-class section (`#cli` + nav link) across every page (homepage, all guides, all playgrounds, footer)
- Create playgrounds hub ([`docs/playgrounds/index.html`](docs/playgrounds/index.html)) with 4-card grid and switcher navigation
- Unify main nav across all pages: Features · Examples · Demo · MCP · CLI · Guides · Playgrounds · GitHub

**Interactive Playgrounds**
- Add [CLI command builder](docs/playgrounds/cli.html) — schema-driven UI with shell preview, validation, 10 presets
- Add [MCP tool explorer](docs/playgrounds/mcp.html) — in-browser PDF generation, config snippets for 4 clients + docstring for any stdio MCP client

**Documentation Content**
- Rewrite [CLI guide](docs/guides/cli.md) for v0.2.0: 4 commands, hybrid layout model, 30+ flags, recipes, security model, v0.1→v0.2 migration
- Update [README ecosystem](README.md) section with v0.2.0 highlights and 4-command example
- Add playground switcher to all 4 playgrounds (Extreme scripts, Medical 800-page, CLI builder, MCP explorer)

**Architecture & Metadata**
- Refresh [`docs/assets/architecture.svg`](docs/assets/architecture.svg):
  - CLI: `3 commands` → `4 commands` (render · sign · inspect · verify)
  - Shaping: `BiDi · Thai · Arabic` → `GSUB · GPOS · BiDi · 16 scripts` (more precise)
  - Crypto: add SHA + CMS to subtitle
  - MCP: clarify `any stdio client` support
- Add `.playground-switcher` CSS class to [`docs/style.css`](docs/style.css) (reusable nav pattern)
- Update image `alt` attributes and SVG `<desc>` for accessibility/SEO

## Site Metrics

| Metric | Count |
| --- | --- |
| Files modified | 19 |
| Files added | 3 (cli.html, mcp.html, index.html in playgrounds/) |
| Lines added | ~1500 (HTML/CSS) |
| Zero build deps | ✅ |
| Backward compatible | ✅ |

## Related Issues

- Addresses user feedback: playground nav was fragmented (extreme-scripts buried in footer, no switcher between playgrounds)
- Aligns docs with recently released pdfnative-cli v0.2.0

## Checklist

- [x] HTML/CSS validates (no build step; manual inspection)
- [x] Navigation links resolve end-to-end (all 14 pages interconnected)
- [x] Playground switcher renders and functions on all 4 playgrounds
- [x] CLI and MCP playground examples generate valid output (manual test with local pdfnative)
- [x] Theme toggle persists across pages (localStorage parity)
- [x] Accessibility: `aria-current`, `aria-label`, semantic HTML (site: all in-page links tested)
- [x] No library code changes (no impact on `npm run test`, `npm run build`, `npm run lint`)
- [x] No CHANGELOG.md update (docs-only release, semver-compliant)
- [x] No breaking changes (all existing docs URLs remain valid; new playgrounds are additive)

## Notes

- **Out of scope**: Lighthouse audit, cross-browser CI, CSS `.mcp-*` → `.tool-*` generalization (future polish)
- **Release strategy**: This is a documentation-only commit. No GitHub Release tag. Website deploys automatically on merge to `main`.
- **Verification**: Open `/docs/playgrounds/` in a browser post-merge; try CLI presets and MCP tool examples to confirm end-to-end UX.