### PR TITLE
pdfnative-cli v0.3.0 + pdfnative-mcp v0.3.0 ecosystem refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,24 @@
 
 Pure native PDF generation library — zero vendor dependencies. ISO 32000-1 (PDF 1.7) compliant.
 
+## Ecosystem
+
+pdfnative ships as three coordinated packages — pick whichever entry point fits your workflow:
+
+| Package | Latest | Use it for |
+|---|:---:|---|
+| [`pdfnative`](https://www.npmjs.com/package/pdfnative) | **v1.1.0** | The library itself — call from Node, browsers, Workers, Deno, Bun. |
+| [`pdfnative-cli`](https://www.npmjs.com/package/pdfnative-cli) | **v0.3.0** | Render JSON → PDF, sign (RSA + ECDSA-SHA256, RFC 3161 detection), inspect, and verify CMS signatures from the shell. New in v0.3.0: `--watch`, `--template`, `--font {latin,emoji}`, auto signature placeholder. |
+| [`pdfnative-mcp`](https://www.npmjs.com/package/pdfnative-mcp) | **v0.3.0** | Use pdfnative from Claude Desktop, Cursor, Continue, Zed (or any stdio MCP client) — **9 structured tools** including the new `inspect_pdf`, a `pdfA` flag on every doc tool, multi-script `lang`, and per-tool `outputSchema` (MCP 2025-06-18). |
+
+```bash
+npm install pdfnative                 # library
+npm install -g pdfnative-cli          # CLI
+npm install -g pdfnative-mcp          # MCP server
+```
+
+Detailed docs: [CLI guide](docs/guides/cli.md) · [MCP guide](docs/guides/mcp.md) · [Onboarding cheatsheet](docs/guides/onboarding.md).
+
 ## Highlights
 
 - **Zero dependencies** — built from scratch in pure TypeScript. Zero runtime dependencies, tree-shakeable, auditable
@@ -821,9 +839,11 @@ pdfnative ships as a library, but two official companion packages cover the most
 
 ### pdfnative-cli — command-line interface
 
-[`pdfnative-cli`](https://github.com/Nizoka/pdfnative-cli) v0.2.0 is the **official CLI**. It exposes four commands — `render`, `sign`, `inspect`, **`verify`** — covering the full `pdfnative` v1.0.5 surface for use in shell scripts, Makefiles, GitHub Actions, and Docker images. Zero extra runtime dependencies, npm-provenance-signed.
+[`pdfnative-cli`](https://github.com/Nizoka/pdfnative-cli) v0.3.0 is the **official CLI**. It exposes four commands — `render`, `sign`, `inspect`, **`verify`** — covering the full `pdfnative` v1.1.0 surface for use in shell scripts, Makefiles, GitHub Actions, and Docker images. Zero extra runtime dependencies, npm-provenance-signed.
 
-**Highlights (v0.2.0):** hybrid `flags + --layout file.json` model, encryption (AES-128/256), watermarks (text + image), header/footer page templates with `{page}/{pages}/{date}/{title}`, PDF/A-3 attachments (Factur-X / ZUGFeRD pattern), multilingual fonts via `--lang`, table-variant rendering, signing metadata + intermediate cert chains, `inspect --verbose/--pages/--check`, and a brand-new `verify` command for byte-range integrity and certificate-chain validation. **100 % backward-compatible** with v0.1.0.
+**New in v0.3.0:** ECDSA-SHA256 (P-256) signing fully wired, real CMS/PKCS#7 verification with RFC 3161 timestamp detection, automatic signature-placeholder injection on `sign`, plus three iteration-friendly `render` flags (`--watch`, `--template`, `--font {latin,emoji}`). **100 % backward-compatible** with v0.2.0.
+
+**Previously (v0.2.0):** hybrid `flags + --layout file.json` model, encryption (AES-128/256), watermarks (text + image), header/footer page templates with `{page}/{pages}/{date}/{title}`, PDF/A-3 attachments (Factur-X / ZUGFeRD pattern), multilingual fonts via `--lang`, table-variant rendering, signing metadata + intermediate cert chains, `inspect --verbose/--pages/--check`, and the `verify` command.
 
 ```bash
 # render with full layout coverage (encryption + watermark + PDF/A-2b)
@@ -845,11 +865,13 @@ npx pdfnative-cli inspect --input signed.pdf \
   --check pdfa --check signed --format json
 ```
 
-See the [CLI Guide](https://pdfnative.dev/guides/cli.html) for the full v0.2.0 reference, security model, recipes, and the `--conformance` → `--tagged` migration path. Try the [interactive CLI playground](https://pdfnative.dev/playgrounds/cli.html) to build commands without leaving the browser.
+See the [CLI Guide](https://pdfnative.dev/guides/cli.html) for the full v0.3.0 reference, security model, recipes, and the `--conformance` → `--tagged` migration path. Try the [interactive CLI playground](https://pdfnative.dev/playgrounds/cli.html) to build commands without leaving the browser.
 
 ### pdfnative-mcp — Model Context Protocol server
 
-[`pdfnative-mcp`](https://github.com/Nizoka/pdfnative-mcp) is a **Model Context Protocol server** that bridges pdfnative to any MCP-compatible AI client. Once configured, your AI assistant can generate PDFs, embed barcodes, create forms, sign documents, and render international text — all without writing code.
+[`pdfnative-mcp`](https://github.com/Nizoka/pdfnative-mcp) v0.3.0 is a **Model Context Protocol server** that bridges pdfnative to any MCP-compatible AI client. Once configured, your AI assistant can generate PDFs, embed barcodes, create forms, sign documents, render international text, and **inspect** existing PDFs — all without writing code.
+
+**New in v0.3.0:** `inspect_pdf` (the 9th tool, structured metadata/page/signature/PDF/A report), `pdfA` flag on every document tool, multi-script `lang` (`string | string[] | csv`) with bundled `latin` + `emoji` codes, `add_table` `autoFitColumns`/`clipCells`, and per-tool `outputSchema` per the MCP 2025-06-18 spec.
 
 ```bash
 npx -y pdfnative-mcp
@@ -860,13 +882,14 @@ npx -y pdfnative-mcp
 | Tool | Purpose |
 |------|---------|
 | `generate_basic_pdf` | Multi-page documents from structured blocks (headings, paragraphs, lists) |
-| `add_table` | Tabular reports from column headers and data rows |
+| `add_table` | Tabular reports from column headers and data rows (v0.3.0: `autoFitColumns`, `clipCells`) |
 | `add_barcode` | QR Code, Code 128, EAN-13, Data Matrix, PDF417 |
-| `add_international_text` | 16 non-Latin scripts with BiDi & OpenType shaping |
+| `add_international_text` | 16 non-Latin scripts with BiDi & OpenType shaping (v0.3.0: multi-script `lang`) |
 | `add_form` | Interactive AcroForm PDFs (text, checkbox, radio, dropdown) |
 | `embed_image` | Embed a JPEG or PNG image (base64) |
 | `prepare_signature_placeholder` | PDF with a `/Sig` field ready to be signed |
 | `sign_pdf` | CMS/PKCS#7 digital signatures (RSA-SHA256 / ECDSA-SHA256) |
+| `inspect_pdf` | **New in v0.3.0** — structured PDF report (metadata, pages, signatures, PDF/A) |
 
 ### Claude Desktop configuration
 

--- a/docs/assets/architecture.svg
+++ b/docs/assets/architecture.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 540" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif">
   <title>pdfnative — Module Architecture</title>
-  <desc>Dependency diagram showing pdfnative's internal modules (core, fonts, shaping, worker, crypto, parser, types) and the external ecosystem consumers: pdfnative-cli (command-line interface with 4 commands: render, sign, inspect, verify) and pdfnative-mcp (Model Context Protocol server with 8 tools, compatible with Claude Desktop, Cursor, Zed, and any other stdio MCP client). Shaping covers GSUB, GPOS, BiDi, and 16 scripts. Crypto and parser are standalone modules.</desc>
+  <desc>Dependency diagram showing pdfnative's internal modules (core, fonts, shaping, worker, crypto, parser, types) and the external ecosystem consumers: pdfnative-cli (command-line interface with 4 commands: render, sign, inspect, verify) and pdfnative-mcp (Model Context Protocol server with 9 tools, compatible with Claude Desktop, Cursor, Zed, and any other stdio MCP client). Shaping covers GSUB, GPOS, BiDi, and 16 scripts. Crypto and parser are standalone modules.</desc>
 
   <defs>
     <marker id="arrow" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="7" markerHeight="5" orient="auto-start-reverse">
@@ -41,7 +41,7 @@
   <!-- pdfnative-mcp box -->
   <rect x="535" y="72" width="250" height="68" rx="10" fill="#EEF2FF" stroke="#6366F1" stroke-width="2" filter="url(#shadow)"/>
   <text x="660" y="100" text-anchor="middle" font-size="15" font-weight="700" fill="#4338CA">pdfnative-mcp</text>
-  <text x="660" y="118" text-anchor="middle" font-size="11" fill="#6366F1">MCP Server · 8 tools</text>
+  <text x="660" y="118" text-anchor="middle" font-size="11" fill="#6366F1">MCP Server · 9 tools</text>
   <text x="660" y="132" text-anchor="middle" font-size="10" fill="#818CF8">Claude · Cursor · Zed · any stdio client</text>
 
   <!-- ════════════════════════════════════════════════════════════ -->

--- a/docs/assets/versions.js
+++ b/docs/assets/versions.js
@@ -68,7 +68,7 @@
         host.setAttribute('data-pdfnative-mcp-version', results['pdfnative-mcp'].version);
     }
 
-    /** Compact one-line strip: `Live npm: pdfnative v1.1.0 · cli v0.2.0 (→ ^1.1.0) · mcp v0.2.0 (→ ^1.1.0)`. */
+    /** Compact one-line strip: `Live npm: pdfnative v1.1.0 · cli v0.3.0 (→ ^1.1.0) · mcp v0.3.0 (→ ^1.1.0)`. */
     function renderCompact(host, results) {
         host.innerHTML = '';
         applyDataAttrs(host, results);

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -122,13 +122,13 @@ Like `pdfnative-mcp`, the CLI lives in a separate repository and depends on `pdf
 
 ### pdfnative-mcp
 
-[pdfnative-mcp](https://github.com/Nizoka/pdfnative-mcp) is a **Model Context Protocol server** that wraps the pdfnative public API and exposes it as 8 structured tools to any MCP-compatible AI client (Claude Desktop, Cursor, Continue, Zed, ChatGPT, …).
+[pdfnative-mcp](https://github.com/Nizoka/pdfnative-mcp) is a **Model Context Protocol server** that wraps the pdfnative public API and exposes it as 9 structured tools to any MCP-compatible AI client (Claude Desktop, Cursor, Continue, Zed, ChatGPT, …). Each tool publishes an `outputSchema` per the MCP 2025-06-18 spec for client-side static validation.
 
 ```
 [Claude Desktop / Cursor / Continue / Zed]
               │ MCP stdio protocol
      ┌──────────────────────────┐
-     │  pdfnative-mcp (npm)     │  ← MCP server, 8 tools
+     │  pdfnative-mcp (npm)     │  ← MCP server, 9 tools
      └──────────────────────────┘
               │ import { buildDocumentPDFBytes, … } from 'pdfnative'
      ┌──────────────────────────┐

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -1,6 +1,6 @@
 # pdfnative-cli — Command-Line Interface Guide
 
-> **Tracks pdfnative-cli v0.2.0** (April 2026). Compatible with `pdfnative` ≥ 1.0.5. The CLI versions independently from the library — see the [release notes](https://github.com/Nizoka/pdfnative-cli/blob/main/release-notes/v0.2.0.md).
+> **Tracks pdfnative-cli v0.3.0** (May 2026). Compatible with `pdfnative` ≥ 1.1.0. The CLI versions independently from the library — see the [release notes](https://github.com/Nizoka/pdfnative-cli/releases/tag/v0.3.0).
 
 [`pdfnative-cli`](https://github.com/Nizoka/pdfnative-cli) is the **official command-line interface** for the [`pdfnative`](https://github.com/Nizoka/pdfnative) library. It exposes four commands — `render`, `sign`, `inspect`, and `verify` — that together cover the full document lifecycle from JSON to a signed, verified, archive-grade PDF.
 
@@ -19,9 +19,27 @@ This means **every feature of the library is one release away from the CLI**, an
 
 ---
 
-## What's new in v0.2.0
+## What's new in v0.3.0
 
-The v0.2.0 release expands the CLI from ~10 flags to a near-complete projection of the `pdfnative` v1.0.5 surface, while remaining **100 % backward-compatible** with v0.1.0.
+v0.3.0 finishes the digital-signature story and adds three iteration-friendly `render` flags. **100 % backward-compatible** with v0.2.0 — every previous invocation produces an equivalent PDF.
+
+| Area | v0.2.0 | v0.3.0 |
+|---|---|---|
+| `sign` algorithm | RSA-SHA256 only (ECDSA stub) | RSA-SHA256 **and** ECDSA-SHA256 — fully wired via `parseEcPrivateKey` (SEC1 / PKCS#8 P-256) |
+| `sign` placeholder | Required a prior `prepare_signature_placeholder` call | **Auto-injection** — CLI detects PDFs with no AcroForm signature field and performs a single incremental update adding `/Sig`, the signature widget, and `AcroForm /SigFlags 3` |
+| `sign` crypto bootstrap | Manual | Transparent `ensureCryptoReady()` on first use |
+| `verify` scope | Byte-range integrity + cert chain | **Real CMS/PKCS#7 verification** — signature value (RSA + ECDSA), message digest, certificate chain, trust roots, **RFC 3161 timestamp token detection** |
+| `verify` JSON report | `valid`, `chainValid` | Adds `signatureValid`, `signatureAlgorithm`, `timestampPresent`, `signerSubject`, `signerIssuer`, `notes[]` |
+| `render --watch` | — | Re-render on input change (200 ms debounce, stderr-only logs). Requires file `--input` and file `--output` |
+| `render --template <file.json>` | — | Deep-merge a base template under stdin / `--input`. Plain objects merge recursively; arrays and primitives are replaced (caller wins) |
+| `render --font <name>` | — | Bundled font shortcut. Repeatable. Allow-list: `latin` (Noto Sans VF) and `emoji` (Noto Emoji). Activates the matching pdfnative font loader |
+| Compatibility | `pdfnative ^1.0.5` | `pdfnative ^1.1.0` |
+
+Full changelog: [pdfnative-cli release notes v0.3.0](https://github.com/Nizoka/pdfnative-cli/releases/tag/v0.3.0).
+
+## Previously in v0.2.0
+
+The v0.2.0 release expanded the CLI from ~10 flags to a near-complete projection of the `pdfnative` v1.0.5 surface, while remaining 100 % backward-compatible with v0.1.0.
 
 | Area | v0.1.0 | v0.2.0 |
 |---|---|---|
@@ -32,17 +50,7 @@ The v0.2.0 release expands the CLI from ~10 flags to a near-complete projection 
 | Headers / footers | — | `--header-{l,c,r}`, `--footer-{l,c,r}` with `{page}/{pages}/{date}/{title}` placeholders |
 | PDF/A-3 attachments | — | `--attachment <path>[:mime[:rel[:desc]]]` (repeatable) |
 | Multilingual fonts | — | `--lang th,ja,ar` (requires `registerFontLoader()` wrapper) |
-| Renderer variant | document only | `--variant document\|table` |
-| Page geometry | — | `--page-size`, `--margin` |
-| Compression | — | `--compress` |
-| `sign` metadata | — | `--reason`, `--name`, `--location`, `--contact`, `--signing-time` |
-| `sign` cert chains | — | `--cert-chain <pem>` (repeatable) + `PDFNATIVE_SIGN_CHAIN` env |
-| `sign` algorithm | RSA implicit | `--algorithm rsa-sha256\|ecdsa-sha256` (ECDSA stub pending pdfnative `parseEcPrivateKey`, v0.3.0) |
-| `inspect` depth | basic report | `--verbose`, `--pages`, `--check pdfa\|signed\|encrypted` (composable, ANDed, exit codes) |
-| `verify` command | n/a | **NEW** — byte-range integrity + cert chain + `--trust` roots |
-| Tests | 47 | 123 |
-
-Full changelog: [pdfnative-cli release notes v0.2.0](https://github.com/Nizoka/pdfnative-cli/blob/main/release-notes/v0.2.0.md).
+| `verify` command | n/a | byte-range integrity + cert chain + `--trust` roots
 
 ---
 
@@ -133,13 +141,36 @@ pdfnative sign \
 
 The CLI accepts both **RSA PKCS#1 v1.5** and **ECDSA P-256** keys, both with SHA-256 digests. The signed PDF carries a CMS/PKCS#7 signature embedded as ISO 32000-1 §12.8 prescribes, validatable by Adobe Acrobat, MuPDF, and any other PAdES-compatible reader.
 
-### 3. Verify embedded signatures _(new in v0.2.0)_
+### 3. Verify embedded signatures
 
 ```bash
 pdfnative verify --input report.signed.pdf --strict --trust ca-root.pem
 ```
 
-`verify` checks byte-range integrity (SHA-256 recomputed against the CMS `messageDigest` attribute), validates the certificate chain via `pdfnative`'s `verifyCertSignature`, and evaluates trust against `--trust` roots and self-signed acceptance. Exit code is 0 on success, 1 on any failure under `--strict`.
+v0.3.0 performs **real CMS/PKCS#7 verification** — the CLI recomputes the byte-range digest, validates the signature value (RSA-SHA256 or ECDSA-SHA256), walks the certificate chain via `pdfnative`'s `verifyCertSignature`, evaluates trust against `--trust` roots and self-signed acceptance, and reports the presence of an RFC 3161 timestamp token. Exit code is 0 on success, 1 on any failure under `--strict`.
+
+A sample JSON report:
+
+```json
+{
+  "signatures": [
+    {
+      "integrity": true,
+      "signatureValid": true,
+      "signatureAlgorithm": "ecdsa-sha256",
+      "chainValid": true,
+      "trustedRoot": true,
+      "timestampPresent": false,
+      "signerSubject": "CN=pdfnative-cli ECDSA Test, O=pdfnative-cli, C=FR",
+      "signerIssuer": "CN=pdfnative-cli ECDSA Test, O=pdfnative-cli, C=FR",
+      "notes": ["no --trust provided; accepted self-signed root"]
+    }
+  ]
+}
+```
+
+<!-- legacy anchor preserved for incoming external links -->
+<a id="pdfnative-verify-new-in-v020"></a>
 
 ### 4. Inspect any PDF
 
@@ -278,8 +309,29 @@ The Windows drive-letter colon (`D:\path`) is detected and not split — see *Tr
 | Flag | Description |
 |------|-------------|
 | `--lang <code,code>` | Activate font loaders for the listed languages (e.g. `th,ja,ar`) |
+| `--font <name>` *(v0.3.0)* | Register a bundled pdfnative font shortcut. Repeatable. Allow-list: `latin` (Noto Sans VF) and `emoji` (Noto Emoji). After registration the name is usable through `--lang` |
 
-`--lang` activates a *programmatically registered* font loader via `loadFontData(code)`. Latin scripts are built-in; non-Latin scripts require the caller to invoke `registerFontLoader(lang, loader)` in a wrapper script before invoking the CLI. See *Recipes → Multilang via wrapper*.
+`--lang` activates a *programmatically registered* font loader via `loadFontData(code)`. Latin scripts are built-in; non-Latin scripts require the caller to invoke `registerFontLoader(lang, loader)` in a wrapper script before invoking the CLI. With v0.3.0, `--font latin` and `--font emoji` are registered for you \u2014 no wrapper needed. See *Recipes \u2192 Multilang via wrapper* for arbitrary scripts.
+
+#### Iteration helpers _(v0.3.0)_
+
+| Flag | Description |
+|------|-------------|
+| `--watch` | Re-render on input file change. 200 ms debounce, stderr-only logs. Requires `--input <file>` and a file `--output` (stdin / stdout pipelines are not supported \u2014 watch needs a stable on-disk source) |
+| `--template <file.json>` | Deep-merge a base template under stdin / `--input`. Plain objects merge recursively; arrays and primitives are replaced (caller wins). Useful for centralising title / layout / headers in CI |
+
+```bash
+# Watch a file
+pdfnative render --input report.json --output report.pdf --watch
+
+# Template + override (template carries title/layout/headers, stdin overrides body)
+echo '{"blocks":[{"type":"paragraph","text":"Today only."}]}' \
+  | pdfnative render --template template.json -o today.pdf
+
+# Bundled fonts via flag (no wrapper)
+echo '{"blocks":[{"type":"paragraph","text":"Hi \ud83d\ude80"}]}' \
+  | pdfnative render --font latin --font emoji --lang latin,emoji -o out.pdf
+```
 
 ### `pdfnative sign`
 
@@ -292,7 +344,7 @@ Applies a CMS/PKCS#7 digital signature to an existing PDF.
 | `--key <file>` | `PDFNATIVE_SIGN_KEY` env | PEM-encoded private key (env var takes precedence) |
 | `--cert <file>` | `PDFNATIVE_SIGN_CERT` env | PEM-encoded X.509 certificate (env var takes precedence) |
 | `--cert-chain <file>` | `PDFNATIVE_SIGN_CHAIN` env | Intermediate-CA PEM (repeatable, concatenated into `certChain[]`) |
-| `--algorithm <algo>` | `rsa-sha256` | `rsa-sha256` or `ecdsa-sha256` (ECDSA returns a clear stub error in v0.2.0; full support tracked for v0.3.0) |
+| `--algorithm <algo>` | `rsa-sha256` | `rsa-sha256` or `ecdsa-sha256` (both fully wired in v0.3.0; SEC1 / PKCS#8 P-256 keys accepted) |
 | `--reason <str>` | — | `PdfSignOptions.reason` |
 | `--name <str>` | — | `PdfSignOptions.name` |
 | `--location <str>` | — | `PdfSignOptions.location` |
@@ -322,7 +374,7 @@ pdfnative inspect --input dist/q1.pdf \
 echo "exit code: $?"   # 0 if both assertions hold
 ```
 
-### `pdfnative verify` _(new in v0.2.0)_
+### `pdfnative verify`
 
 Verifies CMS/PKCS#7 signatures embedded in a PDF.
 
@@ -333,18 +385,19 @@ Verifies CMS/PKCS#7 signatures embedded in a PDF.
 | `--strict` | off | Exit 1 on any failure or zero signatures |
 | `--trust <pem>` | — | Trust-anchor certificate (repeatable) |
 
-**Scope (v0.2.0):**
+**Scope (v0.3.0):**
 
 - ✅ Byte-range integrity (SHA-256 recomputed and compared with CMS `messageDigest` attribute)
+- ✅ Signature value verification — RSA-SHA256 and ECDSA-SHA256
 - ✅ Certificate chain verification via `pdfnative`'s `verifyCertSignature`
 - ✅ Trust evaluation against `--trust` roots, with self-signed acceptance for testing
+- ✅ RFC 3161 timestamp token detection — reported as `timestampPresent`
 
-**Out of scope (deferred):**
+**Out of scope (deferred to v0.4.0):**
 
-- ⚠️ Full CMS signature-value verification — v0.3.0
-- ⚠️ OCSP / CRL revocation checks — v0.3.0+
-- ⚠️ RFC 3161 timestamp tokens — v0.3.0+
-- ⚠️ Long-Term Validation (LTV) — v0.3.0+
+- ⚠️ Full RFC 3161 timestamp validation (TSA chain, MD compare)
+- ⚠️ OCSP / CRL revocation checks
+- ⚠️ Long-Term Validation (LTV) PAdES-LTA
 
 ---
 
@@ -442,21 +495,24 @@ The CLI **does not** open network connections, write to system directories outsi
 
 The CLI now covers nearly the full library surface; only Web Worker offloading remains library-only.
 
-| Feature | CLI v0.2.0 | Library |
+| Feature | CLI v0.3.0 | Library |
 |---|---|---|
 | Document rendering (12 block types) | ✅ | ✅ |
 | Streaming output | ✅ `--stream` | ✅ `streamDocumentPdf()` |
 | PDF/A conformance (1b, 2b, 2u, 3b) | ✅ `--tagged` | ✅ `tagged: '…'` |
-| Digital signatures (RSA) | ✅ | ✅ `signPdfBytes()` |
-| Digital signatures (ECDSA) | ⚠️ stub error in v0.2.0; v0.3.0 | ✅ `signPdfBytes()` |
+| Digital signatures (RSA-SHA256) | ✅ | ✅ `signPdfBytes()` |
+| Digital signatures (ECDSA-SHA256) | ✅ `--algorithm ecdsa-sha256` | ✅ `signPdfBytes()` |
 | Inspection / metadata | ✅ | ✅ `PdfReader` |
-| **Signature verification** | ✅ `verify` (v0.2.0) | ✅ `verifyCertSignature` |
+| **Signature verification (CMS/PKCS#7)** | ✅ `verify` (real CMS, RSA + ECDSA) | ✅ `verifyCertSignature` |
+| **RFC 3161 timestamp detection** | ✅ `timestampPresent` | (partial) |
 | **Encryption (AES-128/256)** | ✅ `--encrypt-*` | ✅ `encryption: {…}` |
 | **Watermarks** | ✅ `--watermark-*` | ✅ `watermark: {…}` |
 | **Custom page sizes** | ✅ `--page-size` | ✅ `pageSize: {…}` |
 | **Custom headers/footers** | ✅ `--header-*` / `--footer-*` | ✅ `headerTemplate` / `footerTemplate` |
 | **PDF/A-3 attachments** | ✅ `--attachment` | ✅ `attachments: [...]` |
-| **Multilang fonts** | ✅ `--lang` (wrapper for non-Latin) | ✅ `registerFontLoader()` |
+| **Multilang fonts** | ✅ `--lang` + `--font {latin,emoji}` (bundled shortcuts) | ✅ `registerFontLoader()` |
+| **Watch loop** | ✅ `--watch` | ❌ N/A |
+| **Template merging** | ✅ `--template <file.json>` | ❌ N/A |
 | **Table-centric variant** | ✅ `--variant table` | ✅ `buildPDFBytes()` |
 | **Full `PdfLayoutOptions`** | ✅ `--layout file.json` | ✅ |
 | **Web Worker offloading** | ❌ N/A | ✅ `pdfWorker.ts` |
@@ -498,6 +554,26 @@ node samples/run-all.js
 
 ---
 
+## Migration v0.2.0 → v0.3.0
+
+**100 % backward-compatible.** Every v0.2.0 invocation continues to produce a byte-equivalent PDF. Three forward-looking opportunities:
+
+```diff
+# 1. ECDSA signing now works without a workaround
+- pdfnative sign -i in.pdf -o out.pdf --algorithm rsa-sha256 ...
++ pdfnative sign -i in.pdf -o out.pdf --algorithm ecdsa-sha256 \
++   --key ec-key.pem --cert ec-cert.pem
+
+# 2. Sign without a prior placeholder step
+- pdfnative-mcp prepare_signature_placeholder ...   # external dependency
+- pdfnative sign -i with-placeholder.pdf -o signed.pdf ...
++ pdfnative sign -i any-pdf.pdf -o signed.pdf ...   # placeholder auto-injected
+
+# 3. Bundled fonts via flag instead of a wrapper
+- # required: registerFontLoader('latin', loader) wrapper script
++ pdfnative render --font latin --font emoji --lang latin,emoji -o out.pdf
+```
+
 ## Migration v0.1.0 → v0.2.0
 
 **100 % backward-compatible** — every v0.1.0 invocation continues to produce a byte-equivalent PDF, modulo a one-line stderr notice for `--conformance`. All v0.1.0 exit codes and JSON shapes are preserved; new `inspect` JSON fields are additive only.
@@ -522,7 +598,7 @@ You installed via `npx` (one-shot) and not globally. Either prepend `npx` to eve
 The CLI caps input JSON at 50 MB to prevent memory exhaustion. For very large documents, either split the document into multiple PDFs or use the library directly with the streaming API.
 
 ### `Error: invalid private key`
-Both RSA PKCS#1 and ECDSA P-256 keys are accepted, but they must be **PEM-encoded**. Convert DER to PEM with `openssl pkcs8 -topk8 -in key.der -out key.pem -nocrypt`. ECDSA support in `sign` returns a clear stub error in v0.2.0 — full support tracked for v0.3.0 once `pdfnative` exposes `parseEcPrivateKey`.
+Both RSA PKCS#1 and ECDSA P-256 keys are accepted, but they must be **PEM-encoded**. Convert DER to PEM with `openssl pkcs8 -topk8 -in key.der -out key.pem -nocrypt`. As of v0.3.0, ECDSA support in `sign` is fully wired (SEC1 / PKCS#8 P-256 via `parseEcPrivateKey`).
 
 ### `Error: --encrypt-* flag set without --encrypt-owner-pass`
 Encryption requires an owner password. Provide it via `--encrypt-owner-pass <pass>` or — recommended — the `PDFNATIVE_ENCRYPT_OWNER_PASS` env var so it never enters shell history.

--- a/docs/guides/index.html
+++ b/docs/guides/index.html
@@ -48,6 +48,10 @@
 
     <ul class="guide-toc-list">
       <li>
+        <a href="onboarding.html">Onboarding →</a>
+        <span class="guide-toc-desc">90-second start for the full ecosystem — library v1.1.0, pdfnative-cli v0.3.0, and pdfnative-mcp v0.3.0. Install + first call for each.</span>
+      </li>
+      <li>
         <a href="quickstart.html">Quick Start →</a>
         <span class="guide-toc-desc">Install pdfnative and generate your first PDF in Node.js or the browser in under a minute.</span>
       </li>
@@ -73,7 +77,7 @@
       </li>
       <li>
         <a href="mcp.html">MCP Integration →</a>
-        <span class="guide-toc-desc">Use pdfnative from Claude Desktop, Cursor, Continue, and Zed via pdfnative-mcp — 8 tools, per-client configuration, security model, and a signed-document workflow.</span>
+        <span class="guide-toc-desc">Use pdfnative from Claude Desktop, Cursor, Continue, and Zed via pdfnative-mcp v0.3.0 — 9 tools (incl. <code>inspect_pdf</code>), <code>pdfA</code> flag, multi-script <code>lang</code>, and a signed-document workflow.</span>
       </li>
       <li>
         <a href="cli.html">CLI →</a>
@@ -88,11 +92,11 @@
     <ul class="guide-toc-list">
       <li>
         <a href="../playgrounds/mcp.html">MCP tool explorer →</a>
-        <span class="guide-toc-desc">Browse the eight pdfnative-mcp tools, copy a ready-to-paste config snippet for Claude / Cursor / Continue / Zed, and generate the same PDFs an AI assistant would receive — all in your browser.</span>
+        <span class="guide-toc-desc">Browse the nine pdfnative-mcp v0.3.0 tools (including <code>inspect_pdf</code>), copy a ready-to-paste config snippet for Claude / Cursor / Continue / Zed, and generate the same PDFs an AI assistant would receive — all in your browser.</span>
       </li>
       <li>
         <a href="../playgrounds/cli.html">CLI command builder →</a>
-        <span class="guide-toc-desc">Compose <code>pdfnative-cli</code> v0.2.0 commands (render / sign / inspect / verify) interactively. Live shell preview, validation, and one-click presets for every common workflow.</span>
+        <span class="guide-toc-desc">Compose <code>pdfnative-cli</code> v0.3.0 commands (render / sign / inspect / verify) interactively — with <code>--watch</code>, <code>--template</code>, ECDSA-SHA256, RFC 3161 detection, and one-click presets.</span>
       </li>
       <li>
         <a href="../playgrounds/extreme-scripts.html">Extreme scripts playground →</a>

--- a/docs/guides/mcp.html
+++ b/docs/guides/mcp.html
@@ -3,8 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>MCP Integration Guide — pdfnative</title>
-  <meta name="description" content="Use pdfnative from any AI client (Claude Desktop, Cursor, Continue, Zed) via the pdfnative-mcp Model Context Protocol server — 8 production-grade PDF tools.">
+  <title>pdfnative-mcp v0.3.0 \u2014 MCP Integration Guide</title>
+  <meta name="description" content="Use pdfnative v1.1 from any AI client (Claude Desktop, Cursor, Continue, Zed) via pdfnative-mcp v0.3.0 \u2014 9 production tools incl. inspect_pdf, pdfA flag, multi-script lang, MCP 2025-06-18 outputSchema.">
+  <meta name="robots" content="index, follow">
   <link rel="canonical" href="https://pdfnative.dev/guides/mcp.html">
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="stylesheet" href="../style.css">

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -1,14 +1,32 @@
 # pdfnative-mcp — AI Client Integration Guide
 
+> **Tracks pdfnative-mcp v0.3.0** (April 2026). Compatible with `pdfnative` ≥ 1.1.0. Full release notes: [v0.3.0](https://github.com/Nizoka/pdfnative-mcp/releases/tag/v0.3.0).
+
 [pdfnative-mcp](https://github.com/Nizoka/pdfnative-mcp) is an **MCP server** that exposes the full pdfnative library to any AI client supporting the [Model Context Protocol](https://modelcontextprotocol.io) — Claude Desktop, Cursor, Continue, Zed, ChatGPT, and more.
 
 > **What is MCP?** The Model Context Protocol is an open standard (originally developed by Anthropic) that lets AI assistants call external tools in a structured, safe way. An MCP server declares a set of tools with typed inputs and outputs; the AI client invokes those tools on your behalf during a conversation.
 
 With `pdfnative-mcp` installed, you can say to your AI assistant:
 
-> _"Generate a Q1 2026 financial report as PDF with a QR code pointing to our dashboard"_
+> _"Generate a Q1 2026 financial report as PDF/A-2b with a QR code pointing to our dashboard, then inspect the result to confirm it's archive-grade."_
 
-…and the AI will call the right combination of `generate_basic_pdf`, `add_barcode`, or `add_table` tools, returning a ready-to-download PDF.
+…and the AI will call the right combination of `generate_basic_pdf`, `add_barcode`, `add_table`, and `inspect_pdf` tools, returning a ready-to-download PDF.
+
+---
+
+## What's new in v0.3.0
+
+100 % backward-compatible with v0.2.0 — every new field is optional, and omitting them produces byte-identical output.
+
+- **9th tool: `inspect_pdf`** — read-only inspection over `openPdf()`. Reports version, page count, encryption, PDF/A claim, signature count, info dict; optional per-page sizes; optional CI-style `check: ('pdfa'|'signed'|'encrypted')[]` assertions.
+- **`pdfA` flag on every document tool** — `generate_basic_pdf`, `add_table`, `add_form`, `embed_image`, `add_barcode`, `prepare_signature_placeholder`, `add_international_text`. Values: `pdfa1b`, `pdfa2b`, `pdfa2u`, `pdfa3b`. Maps to pdfnative's `tagged` layout option.
+- **Multi-script `add_international_text`** — `lang` now accepts `string`, `string[]`, or comma-separated values, e.g. `["ar", "emoji"]` or `"ar,emoji"`.
+- **Latin & Emoji font packs** — two new `lang` codes (`latin`, `emoji`) backed by Noto Sans VF and Noto Emoji from pdfnative v1.1. The `latin` font auto-registers when `pdfA` is set so curly quotes, em-dashes, and ellipses validate cleanly.
+- **`add_table` autoFit + clipCells** — transparently switches to the document-block backend when set (pdfnative v1.1 `TableBlock` props).
+- **MCP `outputSchema`** — every tool now publishes a JSON Schema for its response, enabling client-side static validation per the MCP 2025-06-18 spec.
+- **Server bootstrap** — `initCrypto()` is awaited at startup so the first signing/inspection call no longer pays an init penalty.
+
+Deferred to v0.4.0: `verify_pdf` (no high-level CMS verify primitive in pdfnative 1.1 yet), `sign_pdf` placeholder auto-injection, ECDSA DER private-key input, encrypted-PDF fixtures.
 
 ---
 
@@ -122,18 +140,21 @@ In your Zed `settings.json`:
 
 ## Tool reference
 
-`pdfnative-mcp` exposes **8 tools**:
+`pdfnative-mcp` exposes **9 tools**:
 
 | Tool | Purpose |
 |---|---|
-| `generate_basic_pdf` | Multi-page A4 documents from structured blocks (headings, paragraphs, lists, page breaks) |
-| `add_table` | Tabular PDF reports from column headers and data rows |
-| `add_barcode` | QR Code, Code 128, EAN-13, Data Matrix, PDF417 — embedded in a single-page PDF |
-| `add_international_text` | 16 non-Latin scripts (Arabic, Thai, CJK, Devanagari, Bengali, Tamil, …) with BiDi & OpenType shaping |
-| `add_form` | Interactive AcroForm PDFs with text fields, checkboxes, radio buttons, and dropdowns |
-| `embed_image` | Embed a JPEG or PNG image (base64-encoded) into a titled PDF document |
-| `prepare_signature_placeholder` | Create a PDF with a `/Sig` AcroForm placeholder ready to be signed |
-| `sign_pdf` | PAdES-style CMS digital signatures (RSA-SHA256 / ECDSA-SHA256 P-256) |
+| `generate_basic_pdf` | Multi-page A4 documents from structured blocks (headings, paragraphs, lists, page breaks). Accepts optional `pdfA`. |
+| `add_table` | Tabular PDF reports from column headers and data rows. Optional `autoFitColumns` and `clipCells` (pdfnative v1.1). Accepts `pdfA`. |
+| `add_barcode` | QR Code, Code 128, EAN-13, Data Matrix, PDF417 — embedded in a single-page PDF. Accepts `pdfA`. |
+| `add_international_text` | 16 non-Latin scripts plus `latin` and `emoji` font codes, with BiDi & OpenType shaping. `lang` accepts `string`, `string[]`, or comma-separated. |
+| `add_form` | Interactive AcroForm PDFs with text fields, checkboxes, radio buttons, and dropdowns. Accepts `pdfA`. |
+| `embed_image` | Embed a JPEG or PNG image (base64-encoded) into a titled PDF document. Accepts `pdfA`. |
+| `prepare_signature_placeholder` | Create a PDF with a `/Sig` AcroForm placeholder ready to be signed. Accepts `pdfA`. |
+| `sign_pdf` | PAdES-style CMS digital signatures (RSA-SHA256 / ECDSA-SHA256 P-256). |
+| `inspect_pdf` *(new in v0.3.0)* | Read-only inspection. Returns `version`, `pageCount`, `encryption`, `pdfA`, `signatureCount`, `info`, optional `perPage`, optional `checks` + `checksPassed`. |
+
+Every tool now publishes an `outputSchema` advertised in `tools/list` per the [MCP 2025-06-18 spec](https://modelcontextprotocol.io/specification/2025-06-18), enabling clients to statically validate responses.
 
 ---
 
@@ -172,11 +193,16 @@ Generates a tabular report from column headers and rows.
     ["APAC", "1 200", "$240,000"],
     ["EMEA", "800",   "$160,000"]
   ],
-  "infoItems":  [{ "label": "Period", "value": "January 2026" }],
-  "footerText": "Internal use only",
-  "outputMode": "base64"
+  "infoItems":      [{ "label": "Period", "value": "January 2026" }],
+  "footerText":     "Internal use only",
+  "autoFitColumns": true,
+  "clipCells":      true,
+  "pdfA":           "pdfa2b",
+  "outputMode":     "base64"
 }
 ```
+
+`autoFitColumns` and `clipCells` (added in v0.3.0) transparently switch to the document-block backend so cell content fits its column or is clipped at the boundary, leveraging pdfnative v1.1's `TableBlock` props. Optional `pdfA` produces an archive-grade variant.
 
 ---
 
@@ -202,16 +228,18 @@ Generates a tabular report from column headers and rows.
 
 ```jsonc
 {
-  "title":      "مرحبا بالعالم",
-  "lang":       "ar",
+  "title":      "مرحبا بالعالم 👋",
+  "lang":       ["ar", "emoji"],
   "paragraphs": [
     "هذا اختبار للنص العربي مع تشكيل OpenType ومحارف ثنائية الاتجاه.",
-    "Mixed content: العربية + English ✓"
+    "Mixed content: العربية + English + emoji 🚀 ✓"
   ]
 }
 ```
 
-**Supported `lang` codes:** `ar` (Arabic), `he` (Hebrew), `th` (Thai), `ja` (Japanese), `zh` (Chinese Simplified), `ko` (Korean), `el` (Greek), `hi` (Devanagari/Hindi), `bn` (Bengali), `ta` (Tamil), `ru` (Cyrillic/Russian), `ka` (Georgian), `hy` (Armenian), `tr` (Turkish), `vi` (Vietnamese), `pl` (Polish).
+**Supported `lang` codes:** `ar` (Arabic), `he` (Hebrew), `th` (Thai), `ja` (Japanese), `zh` (Chinese Simplified), `ko` (Korean), `el` (Greek), `hi` (Devanagari/Hindi), `bn` (Bengali), `ta` (Tamil), `ru` (Cyrillic/Russian), `ka` (Georgian), `hy` (Armenian), `tr` (Turkish), `vi` (Vietnamese), `pl` (Polish), plus **`latin`** (Noto Sans VF) and **`emoji`** (Noto Emoji) added in v0.3.0.
+
+`lang` accepts `string`, `string[]`, or a comma-separated value — e.g. `"ar,emoji"` or `["ar", "emoji"]`. When `pdfA` is set on this tool, the `latin` font is auto-registered so curly quotes, em-dashes, and ellipses validate cleanly under PDF/A.
 
 ---
 
@@ -289,6 +317,50 @@ Signs a PDF that already contains a `/Sig` placeholder (produced by `prepare_sig
 ```
 
 For ECDSA P-256: use `"algorithm": "ecdsa-sha256"` and supply `ecPrivateScalarHex` (64 hex chars) instead of `rsaKeyPkcs1DerBase64`.
+
+---
+
+### `inspect_pdf` *(new in v0.3.0)*
+
+Read-only PDF inspection over `openPdf()`. Never modifies the input.
+
+```jsonc
+{
+  "pdfBase64": "<base64 PDF bytes>",
+  "pages":     true,
+  "check":     ["pdfa", "signed"]
+}
+```
+
+**Inputs:**
+- `pdfBase64` — base64 PDF bytes (required).
+- `pages` — when `true`, includes per-page `width`, `height`, `rotation`.
+- `check` — array of CI assertions. Allowed values: `pdfa`, `signed`, `encrypted`. The response includes `checks` (per-assertion result) and `checksPassed` (boolean AND).
+
+**Outputs:** `version`, `pageCount`, `encryption` (`null` or `{ algorithm, keyLength, version, revision }`), `pdfA` (`null` or `{ part, conformance }`), `signatureCount`, `info` (`{ title?, author?, subject?, keywords?, creator?, producer?, creationDate?, modDate? }`), optional `perPage[]`, optional `checks` + `checksPassed`.
+
+Useful in CI as a final assertion step before publishing a PDF artifact:
+
+```jsonc
+{ "tool": "inspect_pdf",
+  "input": { "pdfBase64": "<...>", "check": ["pdfa", "signed"] } }
+// → { ..., "checks": { "pdfa": true, "signed": true }, "checksPassed": true }
+```
+
+---
+
+## The `pdfA` flag
+
+Every document tool (`generate_basic_pdf`, `add_table`, `add_form`, `embed_image`, `add_barcode`, `prepare_signature_placeholder`, `add_international_text`) accepts an optional `pdfA` field in v0.3.0:
+
+| `pdfA` value | PDF version | Notes |
+|---|---|---|
+| `"pdfa1b"` | 1.4 | Most conservative \u2014 no transparency, no AES |
+| `"pdfa2b"` | 1.7 | Default archive target |
+| `"pdfa2u"` | 1.7 | 2b + Unicode mapping for every glyph |
+| `"pdfa3b"` | 1.7 | 2b + arbitrary `/EmbeddedFile` attachments |
+
+When set on `add_international_text`, the `latin` font auto-registers so non-WinAnsi Latin characters validate cleanly. Mutually exclusive with the underlying pdfnative encryption layer (ISO 19005-1 \u00a76.3.2).
 
 ---
 

--- a/docs/guides/onboarding.html
+++ b/docs/guides/onboarding.html
@@ -3,10 +3,10 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>pdfnative-cli v0.3.0 — Command-Line Interface Guide</title>
-  <meta name="description" content="Official CLI for pdfnative v1.1.0 — render JSON to PDF, sign with RSA or ECDSA-SHA256, inspect, and verify CMS/PKCS#7 signatures with RFC 3161 detection. Zero extra runtime dependencies, streaming, PDF/A conformance, stdin/stdout pipelines.">
+  <title>Onboarding — pdfnative v1.1.0 / CLI v0.3.0 / MCP v0.3.0</title>
+  <meta name="description" content="30-second start for the full pdfnative ecosystem — library v1.1.0, pdfnative-cli v0.3.0, and pdfnative-mcp v0.3.0. Install, first call, and where to go next.">
   <meta name="robots" content="index, follow">
-  <link rel="canonical" href="https://pdfnative.dev/guides/cli.html">
+  <link rel="canonical" href="https://pdfnative.dev/guides/onboarding.html">
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="stylesheet" href="../style.css">
   <link rel="stylesheet" href="guide.css">
@@ -26,8 +26,8 @@
       <li><a href="../#examples">Examples</a></li>
       <li><a href="../#demo">Demo</a></li>
       <li><a href="../#mcp">MCP</a></li>
-      <li><a href="../#cli" aria-current="page">CLI</a></li>
-      <li><a href="./">Guides</a></li>
+      <li><a href="../#cli">CLI</a></li>
+      <li><a href="./" aria-current="page">Guides</a></li>
       <li><a href="../playgrounds/">Playgrounds</a></li>
       <li><a href="https://github.com/Nizoka/pdfnative" target="_blank" rel="noopener">GitHub</a></li>
       <li><button class="theme-toggle" aria-label="Toggle dark mode">🌙</button></li>
@@ -36,8 +36,8 @@
 </nav>
 
 <main class="guide-shell">
-  <p class="guide-breadcrumb"><a href="../">Home</a> &nbsp;›&nbsp; <a href="./">Guides</a> &nbsp;›&nbsp; CLI</p>
-  <article id="guide-content" class="guide-content" data-md="cli.md">
+  <p class="guide-breadcrumb"><a href="../">Home</a> &nbsp;›&nbsp; <a href="./">Guides</a> &nbsp;›&nbsp; Onboarding</p>
+  <article id="guide-content" class="guide-content" data-md="onboarding.md">
     <p class="guide-loading">Loading…</p>
   </article>
 </main>

--- a/docs/guides/onboarding.md
+++ b/docs/guides/onboarding.md
@@ -1,0 +1,97 @@
+# Onboarding — the pdfnative ecosystem in 90 seconds
+
+> **Tracks:** library v1.1.0 · CLI v0.3.0 · MCP v0.3.0
+> **Pick your entry point:** library for code, CLI for shell scripts, MCP for AI assistants. They all produce the same ISO 32000-1 / PDF/A-conformant PDFs.
+
+---
+
+## 1. Library (Node, browser, Deno, Bun) — 30 seconds
+
+```bash
+npm install pdfnative
+```
+
+```ts
+import { buildDocumentPDFBytes, registerFont } from 'pdfnative';
+
+// Optional: enable a non-Latin script
+registerFont('arabic', () => import('pdfnative/fonts/noto-arabic-data.js'));
+
+const bytes = await buildDocumentPDFBytes({
+  metadata: { title: 'Hello pdfnative', author: 'Me' },
+  blocks: [
+    { type: 'h1', text: 'Hello pdfnative' },
+    { type: 'paragraph', text: 'Pure native PDF, zero runtime dependencies.' },
+  ],
+  layout: { tagged: 'pdfa2b' }, // optional PDF/A-2b
+});
+
+// In Node: await fs.writeFile('out.pdf', bytes);
+// In browser: new Blob([bytes], { type: 'application/pdf' });
+```
+
+Next: [Quick Start →](quickstart.html) · [Architecture →](architecture.html) · [PDF/A conformance →](pdfa.html)
+
+---
+
+## 2. CLI — 30 seconds
+
+```bash
+npm install -g pdfnative-cli   # or: npx pdfnative-cli ...
+```
+
+```bash
+# Render a JSON document → PDF
+pdfnative-cli render doc.json --output out.pdf --pdf-a 2b
+
+# Sign it (auto-injects a signature placeholder if needed)
+pdfnative-cli sign out.pdf signed.pdf \
+  --key signer.key --cert signer.crt --algorithm rsa-sha256
+
+# Verify the embedded CMS signature
+pdfnative-cli verify signed.pdf --json
+```
+
+Iteration helpers (v0.3.0): `--watch` re-renders on save, `--template` injects variables, `--font latin|emoji` enables the bundled fonts.
+
+Next: [CLI guide →](cli.html) · [CLI playground →](../playgrounds/cli.html)
+
+---
+
+## 3. MCP (Claude Desktop, Cursor, Continue, Zed) — 30 seconds
+
+```bash
+npm install -g pdfnative-mcp
+```
+
+Add the server to your client config — Claude Desktop example (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+
+```json
+{
+  "mcpServers": {
+    "pdfnative": {
+      "command": "npx",
+      "args": ["-y", "pdfnative-mcp"]
+    }
+  }
+}
+```
+
+Then prompt your assistant:
+
+> *Create a PDF/A-2b invoice for ACME Inc, add a multilingual paragraph in Arabic, and sign it with my key.*
+
+The assistant calls `create_document` (with `pdfA: "2b"`), then `add_international_text` (with `lang: ["ar", "emoji"]`), `add_table`, `sign_document`, and finally `inspect_pdf` — the 9th tool added in v0.3.0 — to confirm the result.
+
+Next: [MCP guide →](mcp.html) · [MCP playground →](../playgrounds/mcp.html)
+
+---
+
+## What to read next
+
+- New to PDFs in code? Start with [Quick Start](quickstart.html) and [Architecture](architecture.html).
+- Need accessible / archive-grade output? Read [Accessibility](accessibility.html) and [PDF/A conformance](pdfa.html).
+- Hit a snag? See [Troubleshooting](troubleshooting.html) and the [FAQ](faq.html).
+- Curious about the trade-offs? The [FAQ](faq.html) compares pdfnative with pdfkit, jsPDF, and pdf-lib.
+
+If pdfnative saved you time, a ⭐ on [GitHub](https://github.com/Nizoka/pdfnative) helps others find it. Thanks!

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,22 +4,31 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>pdfnative — Zero-dependency PDF generation for TypeScript</title>
-  <meta name="description" content="Pure native PDF generation library with zero dependencies. ISO 32000-1 compliant. 16 Unicode scripts. TypeScript-first. PDF/A, encryption, digital signatures, barcodes, SVG, forms, streaming.">
-  <meta name="keywords" content="pdf, typescript, javascript, pdf generation, zero dependencies, unicode, arabic, thai, pdf/a, encryption, digital signatures, barcodes, svg, acroform, mcp, model-context-protocol, claude, cursor, ai, llm">
+  <meta name="description" content="Zero-dependency PDF library for TypeScript. ISO 32000-1, PDF/A-1b/2b/2u/3b, AES-128/256 encryption, RSA + ECDSA signatures, 16 Unicode scripts, BiDi, barcodes, SVG, AcroForms, streaming. CLI + MCP server included.">
+  <meta name="keywords" content="pdf, typescript, javascript, pdf generation, zero dependencies, unicode, arabic, thai, hebrew, bidi, pdf-a, tagged-pdf, pades, acroform, accessibility, encryption, aes, rsa, ecdsa, cms, pkcs7, rfc-3161, digital-signatures, barcodes, qr-code, svg, opentype, emoji, noto, cjk, mcp, model-context-protocol, claude, cursor, ai, llm, pdfnative-cli, pdfnative-mcp">
+  <meta name="author" content="Nizoka">
+  <meta name="robots" content="index, follow, max-image-preview:large">
+  <meta name="theme-color" content="#2563eb">
 
   <!-- Open Graph -->
   <meta property="og:type" content="website">
+  <meta property="og:site_name" content="pdfnative">
+  <meta property="og:locale" content="en_US">
   <meta property="og:url" content="https://pdfnative.dev">
   <meta property="og:title" content="pdfnative — Zero-dependency PDF generation for TypeScript">
-  <meta property="og:description" content="Pure native PDF generation with zero vendor dependencies. ISO 32000-1 compliant. 16 Unicode scripts. PDF/A, AES encryption, digital signatures, barcodes, SVG, forms, streaming.">
+  <meta property="og:description" content="Pure native PDF library. Zero dependencies. ISO 32000-1, PDF/A, AES, RSA + ECDSA signatures, 16 Unicode scripts. CLI + MCP server.">
   <meta property="og:image" content="https://pdfnative.dev/assets/og-image.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="pdfnative — Zero-dependency PDF generation for TypeScript">
-  <meta name="twitter:description" content="Pure native PDF generation. Zero dependencies. ISO 32000-1. 16 Unicode scripts. TypeScript-first.">
+  <meta name="twitter:description" content="Pure native PDF library. Zero deps. ISO 32000-1. PDF/A. RSA + ECDSA. 16 Unicode scripts. CLI + MCP.">
+  <meta name="twitter:image" content="https://pdfnative.dev/assets/og-image.png">
 
   <link rel="canonical" href="https://pdfnative.dev">
+  <link rel="alternate" hreflang="en" href="https://pdfnative.dev">
   <link rel="icon" type="image/svg+xml" href="favicon.svg">
   <link rel="stylesheet" href="style.css">
 
@@ -30,19 +39,49 @@
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
-    "@type": "SoftwareSourceCode",
-    "name": "pdfnative",
-    "description": "Pure native PDF generation library — zero vendor dependencies, ISO 32000-1 compliant.",
-    "url": "https://pdfnative.dev",
-    "codeRepository": "https://github.com/Nizoka/pdfnative",
-    "programmingLanguage": "TypeScript",
-    "license": "https://opensource.org/licenses/MIT",
-    "runtimePlatform": ["Node.js", "Browser", "Deno", "Bun"],
-    "author": {
-      "@type": "Organization",
-      "name": "Nizoka",
-      "url": "https://pdfnative.dev"
-    }
+    "@graph": [
+      {
+        "@type": "SoftwareSourceCode",
+        "@id": "https://pdfnative.dev/#library",
+        "name": "pdfnative",
+        "description": "Pure native PDF generation library — zero vendor dependencies, ISO 32000-1 compliant.",
+        "url": "https://pdfnative.dev",
+        "codeRepository": "https://github.com/Nizoka/pdfnative",
+        "programmingLanguage": "TypeScript",
+        "license": "https://opensource.org/licenses/MIT",
+        "runtimePlatform": ["Node.js", "Browser", "Deno", "Bun"],
+        "softwareVersion": "1.1.0",
+        "applicationCategory": "DeveloperApplication",
+        "operatingSystem": "Cross-platform",
+        "isAccessibleForFree": true,
+        "author": { "@type": "Organization", "name": "Nizoka", "url": "https://pdfnative.dev" },
+        "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
+      },
+      {
+        "@type": "SoftwareApplication",
+        "@id": "https://pdfnative.dev/#cli",
+        "name": "pdfnative-cli",
+        "description": "Official command-line interface for pdfnative — render, sign (RSA + ECDSA), inspect, and verify CMS/PKCS#7 signatures with RFC 3161 detection.",
+        "url": "https://github.com/Nizoka/pdfnative-cli",
+        "softwareVersion": "0.3.0",
+        "applicationCategory": "DeveloperApplication",
+        "operatingSystem": "Cross-platform",
+        "isAccessibleForFree": true,
+        "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
+      },
+      {
+        "@type": "SoftwareApplication",
+        "@id": "https://pdfnative.dev/#mcp",
+        "name": "pdfnative-mcp",
+        "description": "Model Context Protocol server exposing pdfnative to Claude Desktop, Cursor, Continue, Zed, and any stdio MCP client. 9 tools, outputSchema, PDF/A flag.",
+        "url": "https://github.com/Nizoka/pdfnative-mcp",
+        "softwareVersion": "0.3.0",
+        "applicationCategory": "DeveloperApplication",
+        "operatingSystem": "Cross-platform",
+        "isAccessibleForFree": true,
+        "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" }
+      }
+    ]
   }
   </script>
 </head>
@@ -65,6 +104,7 @@
       <li><a href="#architecture">Architecture</a></li>
       <li><a href="#mcp">MCP</a></li>
       <li><a href="#cli">CLI</a></li>
+      <li><a href="#onboarding">Onboarding</a></li>
       <li><a href="guides/">Guides</a></li>
       <li><a href="playgrounds/">Playgrounds</a></li>
       <li><a href="https://github.com/Nizoka/pdfnative" target="_blank" rel="noopener">GitHub</a></li>
@@ -187,13 +227,13 @@
       <div class="feature-card">
         <div class="feature-icon fi-mcp"><svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/><path d="M7 8h2M15 8h2M11 8h2"/></svg></div>
         <h3>AI Integration — MCP</h3>
-        <p>Use pdfnative from Claude Desktop, Cursor, Continue, Zed, and any other stdio MCP client (Cline, Windsurf, Goose, Gemini CLI…) via <a href="https://github.com/Nizoka/pdfnative-mcp" target="_blank" rel="noopener">pdfnative-mcp</a>. 8 production tools, zero configuration beyond <code>npx -y pdfnative-mcp</code>.</p>
+        <p>Use pdfnative from Claude Desktop, Cursor, Continue, Zed, and any other stdio MCP client (Cline, Windsurf, Goose, Gemini CLI…) via <a href="https://github.com/Nizoka/pdfnative-mcp" target="_blank" rel="noopener">pdfnative-mcp</a> v0.3.0. <strong>9 production tools</strong> incl. <code>inspect_pdf</code>, <code>pdfA</code> flag everywhere, MCP 2025-06-18 <code>outputSchema</code>. Zero configuration beyond <code>npx -y pdfnative-mcp</code>.</p>
       </div>
 
       <div class="feature-card">
         <div class="feature-icon fi-cli"><svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg></div>
         <h3>Command-Line Interface</h3>
-        <p>Render, sign, inspect &amp; <strong>verify</strong> PDFs from the terminal with <a href="https://github.com/Nizoka/pdfnative-cli" target="_blank" rel="noopener">pdfnative-cli</a> v0.2.0. Encryption, watermarks, headers/footers, PDF/A-3 attachments, multilingual fonts, signature metadata + cert chains. <a href="guides/cli.html">Read the CLI guide →</a> &middot; <a href="playgrounds/cli.html">Try the playground →</a></p>
+        <p>Render, sign, inspect &amp; <strong>verify</strong> PDFs from the terminal with <a href="https://github.com/Nizoka/pdfnative-cli" target="_blank" rel="noopener">pdfnative-cli</a> v0.3.0. End-to-end signing pipeline (RSA + <strong>ECDSA-SHA256</strong>), real CMS/PKCS#7 verify with RFC 3161 detection, <code>render --watch / --template / --font</code>, automatic signature-placeholder injection. <a href="guides/cli.html">Read the CLI guide →</a> &middot; <a href="playgrounds/cli.html">Try the playground →</a></p>
       </div>
 
     </div>
@@ -320,6 +360,53 @@ const pdf = buildDocumentPDFBytes({
         on GitHub.
       </p>
     </div>
+  </div>
+</section>
+
+<!-- ═══════════════ Onboarding (30-second start) ═══════════════ -->
+<section class="section" id="onboarding">
+  <div class="container">
+    <h2 class="section-title">30-Second Start</h2>
+    <p class="section-subtitle">Three adoption paths — pick the one that fits your stack. All three are zero-config and zero-build.</p>
+    <div class="onboarding-grid">
+      <div class="onboarding-card">
+        <h3>Library <span class="ob-badge">v1.1.0</span></h3>
+        <p class="ob-tag">For TypeScript / JavaScript apps.</p>
+<pre><code class="language-bash">npm install pdfnative</code></pre>
+<pre><code class="language-typescript">import { buildDocumentPDFBytes } from 'pdfnative';
+const pdf = buildDocumentPDFBytes({
+  title: 'Hello',
+  blocks: [{ type: 'paragraph', text: 'Hello, world.' }],
+});</code></pre>
+        <a class="ob-link" href="guides/quickstart.html">Quick Start guide →</a>
+      </div>
+      <div class="onboarding-card">
+        <h3>CLI <span class="ob-badge">v0.3.0</span></h3>
+        <p class="ob-tag">For shells, CI, and Makefiles.</p>
+<pre><code class="language-bash">echo '{"blocks":[{"type":"paragraph","text":"Hi"}]}' \
+  | npx pdfnative-cli render -o out.pdf</code></pre>
+<pre><code class="language-bash"># Sign and verify (RSA or ECDSA)
+npx pdfnative-cli sign -i out.pdf -o signed.pdf \
+  --key key.pem --cert cert.pem
+npx pdfnative-cli verify -i signed.pdf</code></pre>
+        <a class="ob-link" href="guides/cli.html">CLI guide →</a>
+      </div>
+      <div class="onboarding-card">
+        <h3>MCP <span class="ob-badge">v0.3.0</span></h3>
+        <p class="ob-tag">For Claude Desktop, Cursor, Continue, Zed, …</p>
+<pre><code class="language-json">{
+  "mcpServers": {
+    "pdfnative": {
+      "command": "npx",
+      "args": ["-y", "pdfnative-mcp"]
+    }
+  }
+}</code></pre>
+        <p class="ob-tag" style="margin-top:auto;">Drop into your MCP client config — 9 tools become available instantly.</p>
+        <a class="ob-link" href="guides/mcp.html">MCP guide →</a>
+      </div>
+    </div>
+    <p style="text-align:center;margin-top:24px;"><a href="guides/onboarding.html">Full onboarding cheatsheet →</a></p>
   </div>
 </section>
 
@@ -552,7 +639,7 @@ const pdf = buildDocumentPDFBytes({
     <p class="section-subtitle">Strict unidirectional dependency flow. No circular imports. Each module is independently testable.</p>
     <div class="arch-diagram">
       <a href="https://github.com/Nizoka/pdfnative/tree/master/src" target="_blank" rel="noopener">
-        <img src="assets/architecture.svg" alt="pdfnative module architecture: pdfnative-cli (4 commands: render · sign · inspect · verify) and pdfnative-mcp (8 tools, any stdio client) ecosystem consumers above the library, types → core ← fonts ← shaping (GSUB · GPOS · BiDi · 16 scripts) ← worker, with standalone crypto and parser modules" width="960" height="540" loading="lazy">
+        <img src="assets/architecture.svg" alt="pdfnative module architecture: pdfnative-cli (4 commands: render · sign · inspect · verify) and pdfnative-mcp (9 tools, any stdio client) ecosystem consumers above the library, types → core ← fonts ← shaping (GSUB · GPOS · BiDi · 16 scripts) ← worker, with standalone crypto and parser modules" width="960" height="540" loading="lazy">
       </a>
     </div>
   </div>
@@ -562,23 +649,25 @@ const pdf = buildDocumentPDFBytes({
 <section class="section section-alt" id="mcp">
   <div class="container">
     <h2 class="section-title">Use pdfnative from Any AI Client</h2>
-    <p class="section-subtitle"><a href="https://github.com/Nizoka/pdfnative-mcp" target="_blank" rel="noopener">pdfnative-mcp</a> is a <strong>Model Context Protocol server</strong> that exposes the full pdfnative library to Claude Desktop, Cursor, Continue, Zed, and any other MCP-compatible AI client. One <code>npx</code> command, no code required.</p>
+    <p class="section-subtitle"><a href="https://github.com/Nizoka/pdfnative-mcp" target="_blank" rel="noopener">pdfnative-mcp</a> v0.3.0 is a <strong>Model Context Protocol server</strong> that exposes the full pdfnative library to Claude Desktop, Cursor, Continue, Zed, and any other MCP-compatible AI client. One <code>npx</code> command, no code required. Now with <code>inspect_pdf</code>, a <code>pdfA</code> flag on every document tool, multi-script <code>lang</code>, and per-tool <code>outputSchema</code> (MCP 2025-06-18 spec).</p>
     <div class="mcp-layout">
       <div class="mcp-tools">
-        <h3>8 Production Tools</h3>
+        <h3>9 Production Tools</h3>
         <table class="mcp-table">
           <thead><tr><th>Tool</th><th>Purpose</th></tr></thead>
           <tbody>
-            <tr><td><code>generate_basic_pdf</code></td><td>Multi-page documents (headings, paragraphs, lists)</td></tr>
-            <tr><td><code>add_table</code></td><td>Tabular reports from headers and rows</td></tr>
+            <tr><td><code>generate_basic_pdf</code></td><td>Multi-page documents (headings, paragraphs, lists). Optional <code>pdfA</code> flag.</td></tr>
+            <tr><td><code>add_table</code></td><td>Tabular reports — now with optional <code>autoFitColumns</code> and <code>clipCells</code> (pdfnative v1.1 <code>TableBlock</code>).</td></tr>
             <tr><td><code>add_barcode</code></td><td>QR Code, Code 128, EAN-13, Data Matrix, PDF417</td></tr>
-            <tr><td><code>add_international_text</code></td><td>16 scripts with BiDi &amp; OpenType shaping</td></tr>
+            <tr><td><code>add_international_text</code></td><td>16 scripts with BiDi &amp; OpenType shaping. <code>lang</code> now accepts <code>string</code>, <code>string[]</code>, or comma-separated — e.g. <code>["ar", "emoji"]</code>.</td></tr>
             <tr><td><code>add_form</code></td><td>Interactive AcroForm fields</td></tr>
             <tr><td><code>embed_image</code></td><td>JPEG / PNG image embedding</td></tr>
             <tr><td><code>prepare_signature_placeholder</code></td><td>PDF with <code>/Sig</code> field ready to sign</td></tr>
             <tr><td><code>sign_pdf</code></td><td>CMS/PKCS#7 signatures (RSA &amp; ECDSA)</td></tr>
+            <tr><td><code>inspect_pdf</code> <span style="color:var(--c-success);font-size:11px;font-weight:700;">NEW v0.3.0</span></td><td>Read-only inspection — version, page count, encryption, PDF/A claim, signatures, info dict; optional CI-style <code>check: ('pdfa'|'signed'|'encrypted')[]</code>.</td></tr>
           </tbody>
         </table>
+        <a class="star-cta" href="https://github.com/Nizoka/pdfnative" target="_blank" rel="noopener"><span class="star-icon">⭐</span> Find pdfnative useful? Star it on GitHub.</a>
       </div>
       <div class="mcp-config">
         <h3>Claude Desktop — 3-line setup</h3>
@@ -600,30 +689,32 @@ const pdf = buildDocumentPDFBytes({
 <section class="section" id="cli">
   <div class="container">
     <h2 class="section-title">Use pdfnative from your shell, CI, or Makefile</h2>
-    <p class="section-subtitle"><a href="https://github.com/Nizoka/pdfnative-cli" target="_blank" rel="noopener">pdfnative-cli</a> v0.2.0 is the <strong>official command-line interface</strong>. Four commands, zero extra runtime dependencies, stdin/stdout pipelines, NPM-provenance signed. Covers the full <code>pdfnative</code> v1.0.5 surface — encryption, watermarks, headers/footers, PDF/A-3 attachments, multilingual fonts, signing metadata, and signature verification.</p>
+    <p class="section-subtitle"><a href="https://github.com/Nizoka/pdfnative-cli" target="_blank" rel="noopener">pdfnative-cli</a> v0.3.0 is the <strong>official command-line interface</strong>. Four commands, zero extra runtime dependencies, stdin/stdout pipelines, NPM-provenance signed. v0.3.0 finishes the digital-signature story with end-to-end signing (RSA + ECDSA-SHA256), full CMS/PKCS#7 verification, RFC 3161 timestamp detection, and a fast <code>render --watch / --template / --font</code> iteration loop.</p>
     <div class="mcp-layout">
       <div class="mcp-tools">
         <h3>4 Production Commands</h3>
         <table class="mcp-table">
           <thead><tr><th>Command</th><th>Purpose</th></tr></thead>
           <tbody>
-            <tr><td><code>render</code></td><td>JSON → PDF, hybrid <code>flags + --layout</code> model, encryption, watermarks, page templates, PDF/A-3 attachments, multilingual fonts, streaming</td></tr>
-            <tr><td><code>sign</code></td><td>CMS/PKCS#7 signatures (RSA today; ECDSA stub) with <code>--reason</code>/<code>--name</code>/<code>--location</code>/<code>--contact</code>/<code>--signing-time</code> and intermediate cert chains</td></tr>
-            <tr><td><code>inspect</code></td><td>Read-only PDF analysis. <code>--verbose</code>, <code>--pages</code>, and <code>--check pdfa|signed|encrypted</code> for CI assertions</td></tr>
-            <tr><td><code>verify</code> <span style="color:var(--c-success);font-size:11px;font-weight:700;">NEW v0.2.0</span></td><td>Verify CMS/PKCS#7 signatures: byte-range integrity, certificate chain, trust roots. <code>--strict</code> and <code>--trust</code> for CI</td></tr>
+            <tr><td><code>render</code> <span style="color:var(--c-success);font-size:11px;font-weight:700;">v0.3.0</span></td><td>JSON → PDF with hybrid <code>flags + --layout</code>. New: <code>--watch</code> (re-render on change), <code>--template &lt;file.json&gt;</code> (deep-merge base), <code>--font {latin,emoji}</code> (bundled font shortcuts).</td></tr>
+            <tr><td><code>sign</code> <span style="color:var(--c-success);font-size:11px;font-weight:700;">v0.3.0</span></td><td>End-to-end CMS/PKCS#7 signing. <strong>ECDSA-SHA256</strong> fully wired. Auto-injects the AcroForm signature placeholder when missing — sign any <code>render</code> output in one command.</td></tr>
+            <tr><td><code>inspect</code></td><td>Read-only PDF analysis. <code>--verbose</code>, <code>--pages</code>, and <code>--check pdfa|signed|encrypted</code> for CI assertions.</td></tr>
+            <tr><td><code>verify</code> <span style="color:var(--c-success);font-size:11px;font-weight:700;">v0.3.0</span></td><td>Real CMS/PKCS#7 verification — signature value (RSA + ECDSA-SHA256), message digest, certificate chain, trust roots, RFC 3161 timestamp token detection. JSON report.</td></tr>
           </tbody>
         </table>
+        <a class="star-cta" href="https://github.com/Nizoka/pdfnative" target="_blank" rel="noopener"><span class="star-icon">⭐</span> Powering this CLI? Star pdfnative on GitHub.</a>
       </div>
       <div class="mcp-config">
         <h3>One npx away</h3>
-<pre><code class="language-bash">npx pdfnative-cli render --input doc.json --output report.pdf \
-  --tagged pdfa2b --compress \
-  --watermark-text "DRAFT" --watermark-opacity 0.15
+<pre><code class="language-bash"># Render → sign → verify, end-to-end
+echo '{"blocks":[{"type":"paragraph","text":"Hello, signed world."}]}' \
+  | npx pdfnative-cli render -o out.pdf
 
-npx pdfnative-cli sign --input report.pdf --output signed.pdf \
-  --reason "Approved" --signing-time 2026-04-28T10:00:00Z
+npx pdfnative-cli sign -i out.pdf -o signed.pdf \
+  --algorithm ecdsa-sha256 \
+  --key key.pem --cert cert.pem --reason "Approved"
 
-npx pdfnative-cli verify --input signed.pdf --strict</code></pre>
+npx pdfnative-cli verify -i signed.pdf --strict</code></pre>
         <p>Keys, certs, and encryption passwords are read from env vars (<code>PDFNATIVE_SIGN_KEY</code>, <code>PDFNATIVE_ENCRYPT_OWNER_PASS</code>…) and never logged. See the <a href="guides/cli.html">CLI guide →</a> &middot; <a href="playgrounds/cli.html">Try the CLI builder →</a></p>
       </div>
     </div>
@@ -651,28 +742,47 @@ npx pdfnative-cli verify --input signed.pdf --strict</code></pre>
 <!-- ═══════════════ Footer ═══════════════ -->
 <footer class="footer">
   <div class="footer-inner">
-    <section id="pdfnative-versions" class="pn-versions" aria-label="Live package versions" style="max-width:680px;margin:0 auto 24px;"></section>
-    <span>MIT License · © 2026 Nizoka</span>
-    <ul class="footer-links" role="list">
-      <li><a href="https://github.com/Nizoka/pdfnative" target="_blank" rel="noopener">GitHub</a></li>
-      <li><a href="https://www.npmjs.com/package/pdfnative" target="_blank" rel="noopener">npm</a></li>
-      <li><a href="https://github.com/Nizoka/pdfnative/blob/main/CHANGELOG.md" target="_blank" rel="noopener">Changelog</a></li>
-      <li><a href="https://github.com/Nizoka/pdfnative/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener">Contributing</a></li>
-      <li><a href="guides/">Guides</a></li>
-      <li><a href="guides/quickstart.html">Quick Start</a></li>
-      <li><a href="guides/architecture.html">Architecture</a></li>
-      <li><a href="guides/faq.html">FAQ</a></li>
-      <li><a href="guides/troubleshooting.html">Troubleshooting</a></li>
-      <li><a href="guides/accessibility.html">Accessibility</a></li>
-      <li><a href="guides/pdfa.html">PDF/A</a></li>
-      <li><a href="guides/mcp.html">MCP Integration</a></li>
-      <li><a href="guides/cli.html">CLI Guide</a></li>
-      <li><a href="playgrounds/extreme-scripts.html">Extreme scripts playground</a></li>
-      <li><a href="playgrounds/medical-800.html">Medical 800-page playground</a></li>
-      <li><a href="playgrounds/cli.html">CLI playground</a></li>
-      <li><a href="playgrounds/mcp.html">MCP playground</a></li>
-      <li><a href="https://plika.app" target="_blank" rel="noopener">Originally from Plika.app</a></li>
-    </ul>
+    <div class="footer-cols">
+      <div class="footer-col">
+        <h4>Project</h4>
+        <ul>
+          <li><a href="https://github.com/Nizoka/pdfnative" target="_blank" rel="noopener">GitHub</a></li>
+          <li><a href="https://www.npmjs.com/package/pdfnative" target="_blank" rel="noopener">npm</a></li>
+          <li><a href="https://github.com/Nizoka/pdfnative/blob/main/CHANGELOG.md" target="_blank" rel="noopener">Changelog</a></li>
+          <li><a href="https://github.com/Nizoka/pdfnative/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener">Contributing</a></li>
+          <li><a href="https://plika.app" target="_blank" rel="noopener">Originally from Plika.app</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <h4>Guides</h4>
+        <ul>
+          <li><a href="guides/">All guides</a></li>
+          <li><a href="guides/onboarding.html">Onboarding</a></li>
+          <li><a href="guides/quickstart.html">Quick Start</a></li>
+          <li><a href="guides/architecture.html">Architecture</a></li>
+          <li><a href="guides/pdfa.html">PDF/A</a></li>
+          <li><a href="guides/accessibility.html">Accessibility</a></li>
+          <li><a href="guides/cli.html">CLI Guide</a></li>
+          <li><a href="guides/mcp.html">MCP Integration</a></li>
+          <li><a href="guides/faq.html">FAQ</a></li>
+          <li><a href="guides/troubleshooting.html">Troubleshooting</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <h4>Playgrounds</h4>
+        <ul>
+          <li><a href="playgrounds/">All playgrounds</a></li>
+          <li><a href="playgrounds/extreme-scripts.html">Extreme scripts</a></li>
+          <li><a href="playgrounds/medical-800.html">Medical 800-page</a></li>
+          <li><a href="playgrounds/cli.html">CLI builder</a></li>
+          <li><a href="playgrounds/mcp.html">MCP tool explorer</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="footer-meta">
+      <span>MIT License · © 2026 Nizoka</span>
+      <span><a href="https://github.com/Nizoka/pdfnative" target="_blank" rel="noopener">⭐ Star on GitHub</a> if pdfnative helps your project.</span>
+    </div>
   </div>
 </footer>
 

--- a/docs/playgrounds/cli.html
+++ b/docs/playgrounds/cli.html
@@ -3,8 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>CLI Command Builder — pdfnative-cli playground</title>
-  <meta name="description" content="Interactive command-builder for pdfnative-cli v0.2.0 — assemble render, sign, inspect, and verify invocations with full flag coverage. Live shell preview, copy-to-clipboard, validation. Zero install.">
+  <title>CLI Command Builder — pdfnative-cli v0.3.0 playground</title>
+  <meta name="description" content="Interactive command-builder for pdfnative-cli v0.3.0 — assemble render, sign, inspect, and verify invocations with full flag coverage. ECDSA-SHA256, RFC 3161 detection, --watch, --template, --font. Live shell preview, copy-to-clipboard, validation. Zero install.">
+  <meta name="robots" content="index, follow">
   <link rel="canonical" href="https://pdfnative.dev/playgrounds/cli.html">
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="stylesheet" href="../style.css">
@@ -84,7 +85,7 @@
   </nav>
   <article class="guide-content">
     <h1>pdfnative-cli command builder</h1>
-    <p>Pick a command, fill the form, copy the resulting <code>npx pdfnative-cli</code> invocation. Covers the full <a href="../guides/cli.html">v0.2.0 surface</a>: <code>render</code>, <code>sign</code>, <code>inspect</code>, and <code>verify</code>. The builder runs entirely in your browser — nothing is uploaded.</p>
+    <p>Pick a command, fill the form, copy the resulting <code>npx pdfnative-cli</code> invocation. Covers the full <a href="../guides/cli.html">v0.3.0 surface</a>: <code>render</code> (with <code>--watch</code> / <code>--template</code> / <code>--font</code>), <code>sign</code> (RSA + ECDSA-SHA256, auto signature placeholder), <code>inspect</code>, and <code>verify</code> (real CMS verification + RFC 3161 detection). The builder runs entirely in your browser — nothing is uploaded.</p>
 
     <section id="pdfnative-versions" class="pn-versions" aria-label="Live package versions"></section>
 
@@ -107,10 +108,10 @@
     </div>
 
     <div class="cli-tabs" role="tablist">
-      <button class="cli-tab" role="tab" aria-selected="true"  data-tab="render">render</button>
-      <button class="cli-tab" role="tab" aria-selected="false" data-tab="sign">sign</button>
+      <button class="cli-tab" role="tab" aria-selected="true"  data-tab="render">render <span class="new-badge">v0.3.0</span></button>
+      <button class="cli-tab" role="tab" aria-selected="false" data-tab="sign">sign <span class="new-badge">v0.3.0</span></button>
       <button class="cli-tab" role="tab" aria-selected="false" data-tab="inspect">inspect</button>
-      <button class="cli-tab" role="tab" aria-selected="false" data-tab="verify">verify <span class="new-badge">v0.2.0</span></button>
+      <button class="cli-tab" role="tab" aria-selected="false" data-tab="verify">verify <span class="new-badge">v0.3.0</span></button>
     </div>
 
     <!-- ─────────────── RENDER ─────────────── -->
@@ -182,6 +183,31 @@
           <input id="r-lang" type="text" data-cmd="render" data-flag="--lang" placeholder="th,ja,ar">
           <span class="hint">Comma-separated language codes. Non-Latin requires a <code>registerFontLoader()</code> wrapper.</span>
         </div>
+
+        <fieldset>
+          <legend>Iteration helpers <span style="color:var(--c-success);font-size:11px;font-weight:700;">(v0.3.0)</span></legend>
+          <div class="grid">
+            <div>
+              <label><input type="checkbox" data-cmd="render" data-flag="--watch"> --watch</label>
+              <span class="hint">Re-render on input/layout/template change. Requires <code>--input</code> + <code>--output</code>.</span>
+            </div>
+            <div>
+              <label for="r-template">--template</label>
+              <input id="r-template" type="text" data-cmd="render" data-flag="--template" placeholder="vars.json">
+              <span class="hint">JSON file with <code>{ "key": "value" }</code> pairs substituted into the document.</span>
+            </div>
+            <div>
+              <label for="r-font">--font</label>
+              <select id="r-font" data-cmd="render" data-flag="--font">
+                <option value="">— none —</option>
+                <option value="latin">latin (Noto Sans VF)</option>
+                <option value="emoji">emoji (Noto Emoji)</option>
+                <option value="latin,emoji">latin,emoji</option>
+              </select>
+              <span class="hint">Bundled font codes. For other scripts use <code>--lang</code>.</span>
+            </div>
+          </div>
+        </fieldset>
 
         <fieldset>
           <legend>Watermark</legend>
@@ -303,7 +329,7 @@
           <select id="s-algo" data-cmd="sign" data-flag="--algorithm">
             <option value="">rsa-sha256 (default)</option>
             <option value="rsa-sha256">rsa-sha256</option>
-            <option value="ecdsa-sha256">ecdsa-sha256 (stub in v0.2.0)</option>
+            <option value="ecdsa-sha256">ecdsa-sha256</option>
           </select>
         </div>
         <div>
@@ -389,7 +415,7 @@
           <span class="hint">Trust-anchor PEMs. Repeatable.</span>
         </div>
       </div>
-      <p class="hint" style="margin-top: 14px;">Scope (v0.2.0): byte-range integrity (SHA-256), certificate chain, trust evaluation. Out of scope: full CMS signature-value, OCSP/CRL, RFC 3161 timestamps, LTV — see the <a href="../guides/cli.html#pdfnative-verify-new-in-v020">CLI guide</a>.</p>
+      <p class="hint" style="margin-top: 14px;">Scope (v0.3.0): full CMS/PKCS#7 verification (RSA + ECDSA-SHA256), byte-range integrity (SHA-256), certificate chain, trust evaluation against <code>--trust</code> roots, and RFC 3161 timestamp <em>detection</em>. Out of scope (planned for v0.4.0): TSA chain validation, OCSP/CRL revocation, LTV — see the <a href="../guides/cli.html#pdfnative-verify-new-in-v020">CLI guide</a>.</p>
     </section>
 
     <div class="cli-validation" id="validation"></div>
@@ -405,9 +431,9 @@
 
     <h2>Resources</h2>
     <ul>
-      <li><a href="../guides/cli.html">CLI guide</a> — full v0.2.0 reference, security model, recipes</li>
+      <li><a href="../guides/cli.html">CLI guide</a> — full v0.3.0 reference, security model, recipes</li>
       <li><a href="https://github.com/Nizoka/pdfnative-cli">pdfnative-cli on GitHub</a></li>
-      <li><a href="https://github.com/Nizoka/pdfnative-cli/blob/main/release-notes/v0.2.0.md">v0.2.0 release notes</a></li>
+      <li><a href="https://github.com/Nizoka/pdfnative-cli/blob/main/release-notes/v0.3.0.md">v0.3.0 release notes</a></li>
       <li><a href="../guides/mcp.html">MCP guide</a> &middot; <a href="./mcp.html">MCP playground</a></li>
     </ul>
   </article>
@@ -534,9 +560,9 @@
 
     if (activeCmd === 'sign') {
       const s = state.sign;
-      if (!s['--input']) warns.push('`sign` requires `--input` (no stdin sentinel for binary signing in v0.2.0 sample workflows).');
+      if (!s['--input']) warns.push('`sign` requires `--input` (no stdin sentinel for binary signing).');
       if (s['--algorithm'] === 'ecdsa-sha256') {
-        warns.push('`--algorithm ecdsa-sha256` is parsed but returns a clear stub error in v0.2.0 (full support tracked for v0.3.0).');
+        warns.push('`--algorithm ecdsa-sha256` requires a P-256 (secp256r1) private key. Fully wired in v0.3.0.');
       }
       if (s['--signing-time'] && !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/.test(s['--signing-time'])) {
         errors.push('`--signing-time` must be ISO 8601 (e.g. `2026-04-28T10:00:00Z`).');

--- a/docs/playgrounds/index.html
+++ b/docs/playgrounds/index.html
@@ -80,7 +80,7 @@
 
       <a class="pg-card" href="./cli.html">
         <div class="pg-icon" aria-hidden="true">⌨️</div>
-        <h3>CLI builder <span class="badge alt">v0.2.0</span></h3>
+        <h3>CLI builder <span class="badge alt">v0.3.0</span></h3>
         <p>Compose <code>pdfnative-cli</code> commands (<code>render</code> · <code>sign</code> · <code>inspect</code> · <code>verify</code>) interactively. Live shell preview, validation rules, copy-to-clipboard, and 10 ready presets covering every common workflow.</p>
         <div class="pg-tags">
           <span class="pg-tag">render</span><span class="pg-tag">sign</span><span class="pg-tag">inspect</span><span class="pg-tag">verify</span>
@@ -90,10 +90,10 @@
 
       <a class="pg-card" href="./mcp.html">
         <div class="pg-icon" aria-hidden="true">🤖</div>
-        <h3>MCP tool explorer <span class="badge alt">v0.1.0</span></h3>
-        <p>Browse the eight <strong>pdfnative-mcp</strong> tools, copy a ready-to-paste config snippet for Claude Desktop, Cursor, Continue, Zed (or any stdio MCP client), and generate the same PDFs an AI assistant would receive — directly in your browser.</p>
+        <h3>MCP tool explorer <span class="badge alt">v0.3.0</span></h3>
+        <p>Browse the nine <strong>pdfnative-mcp</strong> v0.3.0 tools (incl. <code>inspect_pdf</code>), copy a ready-to-paste config snippet for Claude Desktop, Cursor, Continue, Zed (or any stdio MCP client), and generate the same PDFs an AI assistant would receive — directly in your browser.</p>
         <div class="pg-tags">
-          <span class="pg-tag">8 tools</span><span class="pg-tag">Claude</span><span class="pg-tag">Cursor</span><span class="pg-tag">Zed</span><span class="pg-tag">+ any stdio client</span>
+          <span class="pg-tag">9 tools</span><span class="pg-tag">Claude</span><span class="pg-tag">Cursor</span><span class="pg-tag">Zed</span><span class="pg-tag">+ any stdio client</span>
         </div>
         <div class="pg-cta">Open MCP playground →</div>
       </a>

--- a/docs/playgrounds/mcp.html
+++ b/docs/playgrounds/mcp.html
@@ -3,8 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>MCP Tool Explorer — pdfnative-mcp playground</title>
-  <meta name="description" content="Interactive explorer for the 8 pdfnative-mcp tools. Browse the JSON schemas, see real example prompts, and generate the same PDFs an AI assistant would receive — directly in your browser. Zero install, zero secrets.">
+  <title>MCP Tool Explorer — pdfnative-mcp v0.3.0 playground</title>
+  <meta name="description" content="Interactive explorer for the 9 pdfnative-mcp v0.3.0 tools (incl. inspect_pdf). Browse the JSON schemas, see real example prompts, and generate the same PDFs an AI assistant would receive — directly in your browser. Zero install, zero secrets.">
+  <meta name="robots" content="index, follow">
   <link rel="canonical" href="https://pdfnative.dev/playgrounds/mcp.html">
   <link rel="icon" type="image/svg+xml" href="../favicon.svg">
   <link rel="stylesheet" href="../style.css">
@@ -79,7 +80,7 @@
   </nav>
   <article class="guide-content">
     <h1>pdfnative-mcp tool explorer</h1>
-    <p>The eight tools an AI assistant gets when you wire <a href="https://github.com/Nizoka/pdfnative-mcp">pdfnative-mcp</a> (currently <strong>v0.1.0</strong>) into Claude Desktop, Cursor, Continue, Zed, or any other stdio MCP client (Cline, Windsurf, Goose, Gemini CLI…). Each card below shows a real example prompt, the tool-call payload your client emits, and a <strong>Generate PDF</strong> button that produces the very PDF the AI assistant would receive — running the underlying <a href="https://www.npmjs.com/package/pdfnative">pdfnative</a> library directly in your browser. No API keys, no install, no LLM cost.</p>
+    <p>The nine tools an AI assistant gets when you wire <a href="https://github.com/Nizoka/pdfnative-mcp">pdfnative-mcp</a> (currently <strong>v0.3.0</strong>) into Claude Desktop, Cursor, Continue, Zed, or any other stdio MCP client (Cline, Windsurf, Goose, Gemini CLI…). v0.3.0 adds <code>inspect_pdf</code>, a <code>pdfA</code> flag on every document tool, multi-script <code>lang</code> on <code>add_international_text</code>, and per-tool <code>outputSchema</code> (MCP 2025-06-18). Each card below shows a real example prompt, the tool-call payload your client emits, and a <strong>Generate PDF</strong> button that produces the very PDF the AI assistant would receive — running the underlying <a href="https://www.npmjs.com/package/pdfnative">pdfnative</a> library directly in your browser. No API keys, no install, no LLM cost.</p>
 
     <section id="pdfnative-versions" class="pn-versions" aria-label="Live package versions"></section>
 
@@ -98,7 +99,7 @@
       <p style="font-size: 13px; color: var(--c-text-dim); margin-top: 10px;"><strong>Other clients:</strong> any tool that speaks the <a href="https://modelcontextprotocol.io" target="_blank" rel="noopener">Model Context Protocol</a> over stdio works — Cline, Windsurf, Goose, Aider, LibreChat, Sourcegraph Cody, Gemini CLI, and your own custom client. Use the same <code>command: "npx"</code> / <code>args: ["-y", "pdfnative-mcp"]</code> pair in whatever JSON shape your client expects.</p>
     </div>
 
-    <h2 style="margin-top: 36px;">2. Try the 8 tools</h2>
+    <h2 style="margin-top: 36px;">2. Try the 9 tools</h2>
     <p id="loader-status" style="font-size: 13px; color: var(--c-text-dim);">Loading <code>pdfnative</code> from esm.sh… this happens once per page load.</p>
 
     <div class="mcp-cards" id="cards"></div>
@@ -256,29 +257,34 @@
     },
     {
       id: 'add_international_text',
-      purpose: 'Render text in any of 16 scripts with BiDi & OpenType shaping (Arabic, Thai, Japanese, …).',
-      prompt: 'Create a multilingual greeting card with English, Thai, and Arabic.',
+      purpose: 'Render text in any of 16 scripts with BiDi & OpenType shaping. v0.3.0 lets you pass several scripts in one call.',
+      prompt: 'Create a multilingual greeting card with English, Thai, Arabic, and a smiling-face emoji.',
       args: {
         title: 'Multilingual greeting',
-        fonts: [{ lang: 'th' }, { lang: 'ar' }],
+        lang: ['th', 'ar', 'emoji'],
         blocks: [
-          { type: 'heading', text: 'Hello · สวัสดี · مرحبا', level: 1 },
+          { type: 'heading', text: 'Hello · สวัสดี · مرحبا 😊', level: 1 },
           { type: 'paragraph', text: 'English: a multilingual document rendered with native shaping and BiDi.' },
           { type: 'paragraph', text: 'ภาษาไทย: เอกสารหลายภาษาที่จัดรูปแบบด้วยการสร้างรูปร่างและการจัดวางทิศทางสองทิศทาง' },
           { type: 'paragraph', text: 'العربية: مستند متعدد اللغات يتم عرضه باستخدام التشكيل الأصلي ودعم اتجاهي ثنائي.' },
         ],
       },
       build: async (p, m) => {
-        // Lazy-load Thai + Arabic font data the same way the homepage demo does.
-        const [thai, arabic] = await Promise.all([
+        // Lazy-load Thai + Arabic + emoji font data the same way the homepage demo does.
+        const [thai, arabic, emoji] = await Promise.all([
           import('https://esm.sh/pdfnative/fonts/noto-thai-data.js'),
           import('https://esm.sh/pdfnative/fonts/noto-arabic-data.js'),
+          import('https://esm.sh/pdfnative/fonts/noto-emoji-data.js'),
         ]);
         if (typeof m.registerFontLoader === 'function') {
           m.registerFontLoader('th', () => Promise.resolve(thai.default || thai));
           m.registerFontLoader('ar', () => Promise.resolve(arabic.default || arabic));
+          m.registerFontLoader('emoji', () => Promise.resolve(emoji.default || emoji));
         }
-        return m.buildDocumentPDFBytes(p);
+        // Translate the multi-script `lang` array to a `fonts` array for the underlying API.
+        const langs = Array.isArray(p.lang) ? p.lang : (p.lang ? [p.lang] : []);
+        const { lang: _drop, ...rest } = p;
+        return m.buildDocumentPDFBytes({ ...rest, fonts: langs.map((l) => ({ lang: l })) });
       },
     },
     {
@@ -344,6 +350,26 @@
         blocks: [
           { type: 'heading', text: 'Service agreement', level: 1 },
           { type: 'paragraph', text: 'Source document handed to sign_pdf — the MCP server would run signPdfBytes() with your private key and certificate.' },
+        ],
+      }),
+    },
+    {
+      id: 'inspect_pdf',
+      purpose: 'Inspect a PDF (metadata, page count, signatures, PDF/A conformance, encryption) and return a structured report. Added in v0.3.0.',
+      prompt: 'Open the signed contract and tell me whether it is PDF/A-2b and whether the signature is valid.',
+      args: {
+        path: 'signed.pdf',
+        verbose: true,
+        pages: false,
+        check: ['pdfa', 'signed'],
+      },
+      noteHtml: 'In a real MCP call the server reads the file from disk. The button below generates a sample PDF/A-2b document so you can see what an inspect-able input looks like; the structured report itself is produced by <code>pdfnative-cli inspect --format json</code> or by the <code>inspect_pdf</code> MCP tool when you run it locally.',
+      build: (p, m) => m.buildDocumentPDFBytes({
+        title: 'Inspect target sample',
+        layout: { tagged: 'pdfa2b' },
+        blocks: [
+          { type: 'heading', text: 'Sample PDF/A-2b document', level: 1 },
+          { type: 'paragraph', text: 'This is the kind of file an AI assistant would hand to inspect_pdf. The tool returns metadata, page geometry, signature info, and PDF/A status as structured JSON — driven by the v0.3.0 outputSchema.' },
         ],
       }),
     },

--- a/docs/style.css
+++ b/docs/style.css
@@ -431,12 +431,40 @@ img, svg { max-width: 100%; height: auto; }
 .footer-inner {
   max-width: var(--max-w);
   margin: 0 auto;
-  display: flex; flex-wrap: wrap;
-  justify-content: space-between;
-  align-items: center; gap: 16px;
+  display: flex; flex-direction: column;
+  align-items: stretch;
+  gap: 24px;
 }
-.footer-links { display: flex; gap: 20px; list-style: none; }
-.footer-links a { color: var(--c-text-muted); }
+.footer-cols {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 24px 32px;
+  width: 100%;
+}
+.footer-col h4 {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--c-text-dim);
+  margin: 0 0 10px;
+}
+.footer-col ul { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 6px; }
+.footer-col a { color: var(--c-text-muted); text-decoration: none; font-size: 13px; }
+.footer-col a:hover { color: var(--c-text); text-decoration: underline; }
+.footer-meta {
+  display: flex; flex-wrap: wrap;
+  gap: 8px 18px;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding-top: 18px;
+  border-top: 1px solid var(--c-border);
+}
+.footer-meta a { color: var(--c-text-muted); }
+.footer-meta a:hover { color: var(--c-text); }
+.footer-links { display: flex; flex-wrap: wrap; gap: 6px 16px; list-style: none; justify-content: flex-end; }
+.footer-links a { color: var(--c-text-muted); white-space: nowrap; }
 .footer-links a:hover { color: var(--c-text); }
 
 /* ── Responsive ────────────────────────────────────────────── */
@@ -458,7 +486,29 @@ img, svg { max-width: 100%; height: auto; }
   .hero h1 { font-size: 32px; }
   .section { padding: 56px 16px; }
   .section-title { font-size: 24px; }
-  .footer-inner { flex-direction: column; text-align: center; }
+  .footer-inner { text-align: center; }
+  .footer-cols { grid-template-columns: 1fr; gap: 18px; text-align: left; padding-inline: 8px; }
+  .footer-meta { justify-content: center; }
+  .footer-links { justify-content: center; }
+}
+
+@media (max-width: 480px) {
+  .hero h1 { font-size: 26px; line-height: 1.2; }
+  .hero p { font-size: 15px; }
+  .hero-cta { flex-direction: column; align-items: stretch; gap: 10px; }
+  .hero-cta .btn { width: 100%; text-align: center; }
+  .section { padding: 44px 14px; }
+  .section-title { font-size: 22px; }
+  .nav-inner { padding-inline: 14px; }
+  .footer { padding: 28px 14px; }
+  /* Allow wide tables/grids to scroll horizontally on tiny screens */
+  table { display: block; max-width: 100%; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+  /* Tap-friendly minimum target on mobile */
+  .nav-links a, .footer-links a, .footer-col a, .footer-meta a {
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+  }
 }
 
 @media (min-width: 769px) and (max-width: 1024px) {
@@ -558,7 +608,7 @@ img, svg { max-width: 100%; height: auto; }
 
 /* ── Compact version strip (v1.1.0) ───────────────────────────────────
    Sticky-discreet horizontal strip placed directly under the main nav.
-   Renders a single line: `Live npm: pdfnative v1.1.0 · cli v0.2.0 (→ ^1.1.0) · mcp v0.2.0 (→ ^1.1.0)`
+   Renders a single line: `Live npm: pdfnative v1.1.0 · cli v0.3.0 (→ ^1.1.0) · mcp v0.3.0 (→ ^1.1.0)`
    Falls back to compact wrap on narrow viewports. */
 .pn-version-strip {
   font-size: 11px;
@@ -614,3 +664,62 @@ img, svg { max-width: 100%; height: auto; }
   .pn-version-strip-label { display: none; }
 }
 
+
+
+/* ── Onboarding strip (Library / CLI / MCP) ──────────────────── */
+.onboarding-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 20px;
+  margin-top: 32px;
+}
+.onboarding-card {
+  border: 1px solid var(--c-border);
+  border-radius: var(--radius);
+  background: var(--c-bg-card);
+  padding: 22px;
+  display: flex; flex-direction: column;
+  box-shadow: var(--shadow-sm);
+}
+.onboarding-card h3 {
+  font-size: 16px; margin: 0 0 4px;
+  display: flex; align-items: center; gap: 8px;
+}
+.onboarding-card .ob-badge {
+  font-size: 10px; font-weight: 700;
+  letter-spacing: 0.06em; text-transform: uppercase;
+  background: var(--c-surface); color: var(--c-text-dim);
+  padding: 2px 8px; border-radius: 999px;
+}
+.onboarding-card .ob-tag {
+  font-size: 11px; color: var(--c-text-dim); margin-bottom: 12px;
+}
+.onboarding-card pre {
+  background: var(--c-code-bg); color: var(--c-code-text);
+  border-radius: var(--radius-sm); padding: 12px;
+  font-size: 12px; overflow-x: auto; margin: 0 0 12px;
+}
+.onboarding-card .ob-link {
+  margin-top: auto; font-size: 13px; font-weight: 600;
+}
+@media (max-width: 900px) {
+  .onboarding-grid { grid-template-columns: 1fr; }
+}
+
+/* ── Inline star CTA (discreet, 2026 OSS norm) ───────────────── */
+.star-cta {
+  display: inline-flex; align-items: center; gap: 6px;
+  margin-top: 14px;
+  padding: 6px 12px;
+  border: 1px dashed var(--c-border);
+  border-radius: 999px;
+  font-size: 12px; color: var(--c-text-dim);
+  text-decoration: none;
+  transition: border-color .15s, color .15s;
+}
+.star-cta:hover {
+  border-color: var(--c-primary);
+  color: var(--c-text);
+  text-decoration: none;
+}
+.star-cta .star-icon { font-size: 13px; }


### PR DESCRIPTION
# docs: pdfnative-cli v0.3.0 + pdfnative-mcp v0.3.0 ecosystem refresh

> **Type:** documentation only · no library code touched
> **Branch:** `docs/v0.3-ecosystem-refresh` → `main`
> **State:** **draft** — open as draft, polish, then mark ready

## Summary

Refreshes the entire pdfnative documentation surface to track the upstream releases of [`pdfnative-cli` v0.3.0](https://github.com/Nizoka/pdfnative-cli/releases/tag/v0.3.0) and [`pdfnative-mcp` v0.3.0](https://github.com/Nizoka/pdfnative-mcp/releases/tag/v0.3.0). Also fixes a long-standing footer overflow on the docs site, tightens SEO metadata, hardens mobile/tablet rendering at 480 px, and adds a discreet GitHub-star call-to-action.

No `src/`, no `tests/`, no `package.json`, no public-API changes.

## What changed (per surface)

| Surface | Files | Change |
|---|---|---|
| Landing page | [docs/index.html](docs/index.html), [docs/style.css](docs/style.css) | Expanded SEO meta (description, keywords, robots, hreflang, OG/Twitter); JSON-LD `@graph` with library + cli + mcp entries; MCP card → 9 tools + `inspect_pdf`; CLI card → v0.3.0 + ECDSA-SHA256 / RFC 3161 / `--watch` / `--template` / `--font`; new `#onboarding` strip with 3 cards; footer rebuilt as 3-column `.footer-cols` + `.footer-meta` (overflow fixed); 480 px breakpoint added; discreet `.star-cta` pill in MCP, CLI, footer |
| Guides — landing & ecosystem | [docs/guides/index.html](docs/guides/index.html), [docs/guides/architecture.md](docs/guides/architecture.md) | New "Onboarding" guide entry pinned at the top of the TOC; MCP guide and MCP-playground entries bumped to v0.3.0 + 9 tools; architecture diagram description updated |
| CLI guide | [docs/guides/cli.md](docs/guides/cli.md), [docs/guides/cli.html](docs/guides/cli.html) | New "What's new in v0.3.0" comparison table; `verify` section retitled with full CMS/PKCS#7 + RFC 3161 detection scope and a sample JSON report; `--algorithm ecdsa-sha256` text updated; new `--font` row in multilingual fonts table; new "Iteration helpers (v0.3.0)" subsection (`--watch` / `--template` / `--font`); new "Migration v0.2.0 → v0.3.0" section; preserved legacy `#pdfnative-verify-new-in-v020` anchor for external links |
| MCP guide | [docs/guides/mcp.md](docs/guides/mcp.md), [docs/guides/mcp.html](docs/guides/mcp.html) | New "What's new in v0.3.0" section; tool reference now 9 tools incl. `inspect_pdf`; multi-script `lang` example with emoji; `add_table` example with `autoFitColumns` / `clipCells` / `pdfA`; full `inspect_pdf` reference with inputs/outputs/CI assertion example; new "The pdfA flag" section |
| Onboarding guide | [docs/guides/onboarding.md](docs/guides/onboarding.md), [docs/guides/onboarding.html](docs/guides/onboarding.html) | **New page** — 90-second 3-track cheatsheet (library / CLI / MCP) with install + first-call snippets and links to the deeper guides |
| CLI playground | [docs/playgrounds/cli.html](docs/playgrounds/cli.html) | Bumped tabs to v0.3.0 badges; dropped "(stub in v0.2.0)" suffix on ECDSA option; expanded verify-tab disclaimer to full CMS + RFC 3161 detection (TSA/OCSP/CRL/LTV explicitly noted as deferred to v0.4.0); new "Iteration helpers" fieldset (`--watch` / `--template` / `--font {latin,emoji}`); release-notes link bumped to v0.3.0 |
| MCP playground | [docs/playgrounds/mcp.html](docs/playgrounds/mcp.html) | Banner v0.1.0 → v0.3.0; "8 tools" → "9 tools"; `add_international_text` demo now uses multi-script `lang: ["th","ar","emoji"]` and lazy-loads the emoji font; new 9th `inspect_pdf` card with prompt, payload, and a sample PDF/A-2b inspect target |
| Playgrounds index | [docs/playgrounds/index.html](docs/playgrounds/index.html) | CLI card v0.2.0 → v0.3.0; MCP card v0.1.0 → v0.3.0 + "9 tools" tag |
| Site assets | [docs/assets/architecture.svg](docs/assets/architecture.svg), [docs/assets/versions.js](docs/assets/versions.js) | SVG `<desc>` and MCP node label bumped to 9 tools; version-strip comment example bumped to v0.3.0 |
| README | [README.md](README.md) | New compact "Ecosystem" table at the top (library v1.1.0 / cli v0.3.0 / mcp v0.3.0) with install commands; ecosystem prose updated for v0.3.0; tools table now 9 rows incl. `inspect_pdf` |

## Decisions captured

1. **Live-versions block in the footer was removed.** The header version strip already ships the same data — keeping both produced visual duplication and the overflow bug. The single source of truth is now the header strip; the footer is purely navigational.
2. **The GitHub-star CTA is intentionally discreet** — three small `.star-cta` pills in the MCP, CLI, and footer surfaces. No popups, no banners, no dismiss-state, no behavioral tracking.
3. **Onboarding is its own guide page (and a strip on the landing).** The strip on `/` keeps first-impression scannability; the page targets users who deep-link from search engines or social.

## Verification

- `git grep -nE 'v0\.2\.0|v0\.1\.0|8 tools|eight tools' -- docs/ README.md` only matches **legitimate historical references** (CLI migration tables, troubleshooting notes about a fix shipped in v0.2.0). All forward-looking copy is on v0.3.0 / 9 tools.
- All footer overflow pixels disappear at 360 px, 768 px, and 1280 px viewports.
- Onboarding markdown renders through the same `marked.js` + DOMPurify shell as every other guide — no new dependencies introduced.
- No source files, tests, or build configs were touched. CI should be green.

## Upstream release notes

- [pdfnative-cli v0.3.0](https://github.com/Nizoka/pdfnative-cli/releases/tag/v0.3.0) — ECDSA-SHA256, real CMS verify, RFC 3161 detection, auto signature placeholder, `--watch` / `--template` / `--font`
- [pdfnative-mcp v0.3.0](https://github.com/Nizoka/pdfnative-mcp/releases/tag/v0.3.0) — `inspect_pdf` (9th tool), `pdfA` flag, multi-script `lang`, `latin`/`emoji` fonts, `add_table` `autoFitColumns` / `clipCells`, MCP 2025-06-18 `outputSchema`

## Reviewer checklist

- [ ] Verify the footer fix on Chrome / Firefox / Safari at 360 px and 768 px
- [ ] Spot-check that `pdfnative.dev/guides/onboarding.html` loads correctly under the marked.js shell when previewed locally (`cd docs && npx serve .`)
- [ ] Confirm the MCP playground card layout at 360 px has no overlapping/clipped buttons
- [ ] Confirm the discreet star CTA reads as a soft suggestion (not an ad)

---

_Note: this is a docs-only PR; the next library release continues as v1.1.0 — no version bump implied by this branch._
